### PR TITLE
Fix typo in category for Super Pang (World 900914)

### DIFF
--- a/ArcadeDatabase_CSV/ArcadeDatabase220908.csv
+++ b/ArcadeDatabase_CSV/ArcadeDatabase220908.csv
@@ -1649,9 +1649,9 @@ wrestwar2,"Wrestle War (W, Set 2)",World,Set 2,yes,Wrestle War,Sega System 16,,n
 pang,Pang,World,,no,Pang,Capcom Mitchell,,no,no,1989,Mitchell,Puzzle - Platform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
 bbros,Buster Bros. (USA),USA,,yes,Pang,Capcom Mitchell,,no,no,1989,Mitchell,Puzzle - Platform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
 pompingw,Pomping World (Japan),Japan,,yes,Pang,Capcom Mitchell,,no,no,1989,Mitchell,Puzzle - Platform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
-spang,Super Pang (World 900914),World,,no,Super Pang,Capcom Mitchell,,no,no,1990,Mitchell,Puzzle - Paltform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
-ssbros,Super Buster Bros. (USA 901001),USA,,yes,Super Pang,Capcom Mitchell,,no,no,1990,Mitchell,Puzzle - Paltform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
-spangj,Super Pang (Japan 901023),Japan,,yes,Super Pang,Capcom Mitchell,,no,no,1990,Mitchell,Puzzle - Paltform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
+spang,Super Pang (World 900914),World,,no,Super Pang,Capcom Mitchell,,no,no,1990,Mitchell,Puzzle - Platform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
+ssbros,Super Buster Bros. (USA 901001),USA,,yes,Super Pang,Capcom Mitchell,,no,no,1990,Mitchell,Puzzle - Platform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
+spangj,Super Pang (Japan 901023),Japan,,yes,Super Pang,Capcom Mitchell,,no,no,1990,Mitchell,Puzzle - Platform,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
 batrideru,Armed Police Batrider (USA) (Fri Feb 13 1998),USA,,no,Armed Police Batrider,Toaplan 2,,no,no,1998,Raizing / Eighting,Shooter - Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
 batriderc,Armed Police Batrider (China) (Fri Feb 13 1998),World,,yes,Armed Police Batrider,Toaplan 2,,no,no,1998,Raizing / Eighting,Shooter - Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
 batriderhk,Armed Police Batrider (Hong Kong) (Mon Dec 22 1997),World,,yes,Armed Police Batrider,Toaplan 2,,no,no,1998,Raizing / Eighting,Shooter - Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3

--- a/mad/Super Buster Bros. (USA 901001).mad
+++ b/mad/Super Buster Bros. (USA 901001).mad
@@ -13,7 +13,7 @@
 	<bootleg>no</bootleg>
 	<year>1990</year>
 	<manufacturer>Mitchell</manufacturer>
-	<category>Puzzle - Paltform</category>
+	<category>Puzzle - Platform</category>
 
 	<resolution>15kHz</resolution>
 	<rotation>horizontal</rotation>

--- a/mad/Super Pang (Japan 901023).mad
+++ b/mad/Super Pang (Japan 901023).mad
@@ -13,7 +13,7 @@
 	<bootleg>no</bootleg>
 	<year>1990</year>
 	<manufacturer>Mitchell</manufacturer>
-	<category>Puzzle - Paltform</category>
+	<category>Puzzle - Platform</category>
 
 	<resolution>15kHz</resolution>
 	<rotation>horizontal</rotation>

--- a/mad/Super Pang (World 900914).mad
+++ b/mad/Super Pang (World 900914).mad
@@ -13,7 +13,7 @@
 	<bootleg>no</bootleg>
 	<year>1990</year>
 	<manufacturer>Mitchell</manufacturer>
-	<category>Puzzle - Paltform</category>
+	<category>Puzzle - Platform</category>
 
 	<resolution>15kHz</resolution>
 	<rotation>horizontal</rotation>


### PR DESCRIPTION
"Paltform" -> "Platform"
Initially reported in https://github.com/theypsilon/_arcade-organizer/issues/56