### PR TITLE
Set flip=yes for Ajax hardware (ajax, ajaxj, typhoon)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2554,9 +2554,9 @@ lghostj,Laser Ghost (JP),Japan,FD1094 317-0164,yes,Laser Ghost,Sega System 18,,n
 lghostu,Laser Ghost (US),USA,FD1094 317-0165,yes,Laser Ghost,Sega System 18,,no,no,1990,Sega,Shooter - Gun,,15kHz,horizontal,,,2-3 (simultaneous),lightgun,lightgun,2
 desertbr,Desert Breaker (W),World,FD1094 317-0196,no,,Sega System 18,,no,no,1992,Sega,Shooter - Walking,,15kHz,vertical (ccw),,,2-3 (simultaneous),8-way,,3
 desertbrj,Desert Breaker (JP),World,FD1094 317-0194,yes,Desert Breaker,Sega System 18,,no,no,1992,Sega,Shooter - Walking,,15kHz,vertical (ccw),,,2-3 (simultaneous),8-way,,3
-ajax,Ajax,World,,no,,Konami Ajax hardware,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-ajaxj,Ajax (JP),Japan,,yes,Ajax,Konami Ajax hardware,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-typhoon,Typhoon,World,,yes,Ajax,Konami Ajax hardware,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
+ajax,Ajax,World,,no,,Konami Ajax hardware,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+ajaxj,Ajax (JP),Japan,,yes,Ajax,Konami Ajax hardware,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+typhoon,Typhoon,World,,yes,Ajax,Konami Ajax hardware,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
 starforc,Star Force,World,,no,,Tecmo Senjyo hardware,Star Force,no,no,1984,Tehkan,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,1
 baluba,Baluba-louk no Densetsu (JP),Japan,,no,,Tecmo Senjyo hardware,,no,no,1986,"Able Corp, Ltd",Platform - Run Jump,,15kHz,vertical (cw),,,2 (alternating),8-way,,1
 megaforc,Mega Force (W),World,,no,Star Force,Tecmo Senjyo hardware,Star Force,no,no,1984,Tehkan,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,1


### PR DESCRIPTION
### Summary

The three Konami **Ajax**-hardware games — `ajax` (Ajax), `ajaxj` (Ajax JP), `typhoon` (Typhoon), all on the `jtajax` core — are natively `vertical (cw)` with an **empty flip** column. As a result they're tagged `screentatecwnoflip` (no `screentateccw`) and are excluded by CCW-oriented tate downloader filters, so they never download to CCW cabinets.

### Verification

Tested on real hardware (MiSTer Pi, physically CCW CRT):
- Default orientation is CW → displays upside-down on a CCW tube.
- The core's **Flip Screen** control in the OSD (the game's hardware DSW3 flip DIP) flips it right-side-up as advertised, and the setting persists — so the game is fully playable in the correct orientation on a CCW cabinet.

This is the same practical "it can be flipped → `flip=yes`" call applied to Air Gallet (#44). Setting `flip=yes` grants `screentateccw`/`screentateflip` so all three variants download in the correct orientation for CCW users while remaining available to CW users.

### Change

`ArcadeDatabase.csv`: flip column empty → `yes` on the `ajax`, `ajaxj`, and `typhoon` rows. No other fields touched; `mad/` untouched (CI regenerates it).

/cc @theypsilon