### PR TITLE
Set flip=yes for Avengers hardware (avengers, avengersa/b/c, buraiken, buraikenb)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2464,12 +2464,12 @@ gradius,"Gradius (JP, ROM Version)",Japan,Rom Version,no,Nemesis,Konami GX400,Gr
 gwarrior,Galactic Warriors,World,,no,,Konami GX400,,no,no,1985,Konami,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 twinbee,TwinBee (ROM Version),World,Rom Version,no,,Konami GX400,Twin Bee,no,no,1985,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
 twinbeeb,TwinBee (Bubble System),World,Bubble System,no,Bubble System Bios,Konami GX400,Twin Bee,no,no,1985,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-avengers,"Avengers (US, Rev C)",USA,Rev C,no,,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-avengersb,Avengers (US),USA,,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-avengersa,"Avengers (US, Rev A)",USA,Rev A,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-avengersc,"Avengers (US, Unk Rev)",USA,Unknown Rev,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-buraikenb,Hissatsu Buraiken (JP) [bl],Japan,bootleg,yes,Avengers,Capcom CPS-0,,no,yes,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-buraiken,"Hissatsu Buraiken (JP, Rev A)",Japan,Rev A,no,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
+avengers,"Avengers (US, Rev C)",USA,Rev C,no,,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
+avengersb,Avengers (US),USA,,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
+avengersa,"Avengers (US, Rev A)",USA,Rev A,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
+avengersc,"Avengers (US, Unk Rev)",USA,Unknown Rev,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
+buraikenb,Hissatsu Buraiken (JP) [bl],Japan,bootleg,yes,Avengers,Capcom CPS-0,,no,yes,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
+buraiken,"Hissatsu Buraiken (JP, Rev A)",Japan,Rev A,no,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 pmonster,Gamushara Battle! Puchi Monster (JP),Japan,990519,no,,Capcom CPS-1,,no,no,1999,Capcom,Medal Game - Versus,,15kHz,horizontal,,,1,Buttons,,2
 vulcan,Vulcan Venture (New),World,New,no,,Konami Twin16 hardware,Gradius,no,no,1988,Konami,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
 vulcana,Vulcan Venture (Old),World,Old,yes,Vulcan Venture,Konami Twin16 hardware,Gradius,no,no,1988,Konami,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3


### PR DESCRIPTION
## What

Sets `flip=yes` on the six Avengers / Hissatsu Buraiken rows (`avengers`, `avengersa`, `avengersb`, `avengersc`, `buraiken`, `buraikenb`) — all the same Capcom "CPS-0" hardware on the JOTEGO `jttrojan` core.

## Why

These rows are natively `vertical (cw)` with an empty `flip` column, so they get tagged `screen_tate_cw_noflip` (no `screen_tate_ccw`) and are excluded by CCW-cabinet download filters — the game never appears on a CCW tate setup even though the core can display it correctly.

The `jttrojan` core supports a full 180° flip: the MRA is JTFRAME-vertical (`01 80` mod) and the hardware **"Flip Screen"** DSW is exposed in the OSD dipswitches page. Verified on real hardware (MiSTer + physical CCW CRT): default boots CW/upside-down, and the OSD Flip Screen option turns it right-side-up and persists.

Setting `flip=yes` grants `screen_tate_ccw` / `screen_tate_flip` so the title downloads correctly oriented on both tube orientations. This mirrors the treatment of the Ajax-hardware rows.

## Notes

- Only the `flip` column changes: 6 insertions / 6 deletions, 22 fields each. `mad/` left untouched (CI regenerates it via `csv2mad.py`).
- FYI unrelated to this change: the parent row's `name` is "Avengers (US, Rev C)" while jotego's distributed MRA/MAME `avengers` set is "Avengers (US, rev. D)". Happy to correct the naming in a follow-up if desired.

/cc @theypsilon