### PR TITLE
Set flip=yes for CW-native Namco System 1 games (jtshouse)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2353,12 +2353,12 @@ pacmaniaj,Pac-Mania (JP),Japan,,no,Pac-Mania,Namco System-1,Pac-Man,no,no,1987,N
 shadowld,Shadowland (YD3),World,YD3,no,,Namco System-1,,no,no,1987,Namco,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,3
 youkaidk2,"Youkai Douchuuki (JP, New Ver. (YD2, Rev B))",Japan,"New Ver. (YD2, Rev B)",no,Shadowland,Namco System-1,,no,no,1987,Namco,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,3
 youkaidk1,"Youkai Douchuuki (JP, Old Ver. (YD1))",Japan,Old Ver. (YD1),yes,Shadowland,Namco System-1,,no,no,1987,Namco,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,3
-dspirit,Dragon Spirit (New Ver. (DS3)),World,New Ver. (DS3),no,,Namco System-1,Dragon Spirit,no,no,1987,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-dspirit2,Dragon Spirit (DS2),World,DS2,yes,Dragon Spirit,Namco System-1,Dragon Spirit,no,no,1987,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-dspirit1,Dragon Spirit (Old Ver. (DS1)),World,Old Ver. (DS1),yes,Dragon Spirit,Namco System-1,Dragon Spirit,no,no,1987,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-blazer,Blazer (JP),Japan,,no,,Namco System-1,,no,no,1987,Namco,Shooter - Driving Diagonal,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-quester,Quester (JP),Japan,,no,,Namco System-1,,no,no,1987,Namco,Ball &amp; Paddle - Breakout,,15kHz,vertical (cw),,,2 (alternating),Dial,Dial,1
-questers,Quester Special Edition (JP),Japan,,no,Quester,Namco System-1,,no,no,1987,Namco,Ball &amp; Paddle - Breakout,,15kHz,vertical (cw),,,2 (alternating),Dial,Dial,1
+dspirit,Dragon Spirit (New Ver. (DS3)),World,New Ver. (DS3),no,,Namco System-1,Dragon Spirit,no,no,1987,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+dspirit2,Dragon Spirit (DS2),World,DS2,yes,Dragon Spirit,Namco System-1,Dragon Spirit,no,no,1987,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+dspirit1,Dragon Spirit (Old Ver. (DS1)),World,Old Ver. (DS1),yes,Dragon Spirit,Namco System-1,Dragon Spirit,no,no,1987,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+blazer,Blazer (JP),Japan,,no,,Namco System-1,,no,no,1987,Namco,Shooter - Driving Diagonal,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+quester,Quester (JP),Japan,,no,,Namco System-1,,no,no,1987,Namco,Ball &amp; Paddle - Breakout,,15kHz,vertical (cw),yes,,2 (alternating),Dial,Dial,1
+questers,Quester Special Edition (JP),Japan,,no,Quester,Namco System-1,,no,no,1987,Namco,Ball &amp; Paddle - Breakout,,15kHz,vertical (cw),yes,,2 (alternating),Dial,Dial,1
 ws,Pro Yakyuu World Stadium (JP),Japan,,no,,Namco System-1,World Stadium,no,no,1988,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 ws89,Pro Yakyuu World Stadium '89 (JP),Japan,,no,Pro Yakyuu World Stadium,Namco System-1,World Stadium,no,no,1988,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 ws90,Pro Yakyuu World Stadium '90 (JP),Japan,,no,Pro Yakyuu World Stadium,Namco System-1,World Stadium,no,no,1988,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
@@ -2369,10 +2369,10 @@ mmaze2,"Marchen Maze (JP, Hack)",Japan,Hack,yes,Marchen Maze,Namco System-1,,no,
 bakutotu,Bakutotsu Kijuutei,Japan,,no,,Namco System-1,Baraduke,no,no,1988,Namco,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
 wldcourt,Pro Tennis World Court (JP),Japan,,no,,Namco System-1,World Court,no,no,1988,Namco,Sports - Tennis,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 faceoff,"Face Off (JP, 2P)",Japan,,no,,Namco System-1,,no,no,1988,Namco,Sports - Hockey,,15kHz,horizontal,,,2 (simultaneous),8-way double,Double joystick,2
-rompers,"Rompers (JP, New Ver. (Rev B))",Japan,Rev B,no,,Namco System-1,,no,no,1989,Namco,Maze - Collect,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-romperso,"Rompers (JP, Old Ver.)",Japan,Old ver,yes,Rompers,Namco System-1,,no,no,1989,Namco,Maze - Collect,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
+rompers,"Rompers (JP, New Ver. (Rev B))",Japan,Rev B,no,,Namco System-1,,no,no,1989,Namco,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
+romperso,"Rompers (JP, Old Ver.)",Japan,Old ver,yes,Rompers,Namco System-1,,no,no,1989,Namco,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
 blastoff,Blast Off (JP),Japan,,no,,Namco System-1,Bosconian,no,no,1989,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
-dangseed,Dangerous Seed (JP),Japan,,no,,Namco System-1,,no,no,1989,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,3
+dangseed,Dangerous Seed (JP),Japan,,no,,Namco System-1,,no,no,1989,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,3
 pistoldm,Pistol Daimyo no Bouken (JP),Japan,,no,,Namco System-1,,no,no,1990,Namco,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
 boxyboy,"Boxy Boy (W, SB2)",World,SB2,no,,Namco System-1,,no,no,1990,Namco,Maze - Blocks,,15kHz,horizontal,,,2 (alternating),8-way,,3
 boxyboya,Boxy Boy (SB-),World,SB2,yes,Boxy Boy,Namco System-1,,no,no,1990,Namco,Maze - Blocks,,15kHz,horizontal,,,2 (alternating),8-way,,3


### PR DESCRIPTION
## What

Sets `flip=yes` for 9 rows of natively **vertical (cw)** Namco System 1 games running on the `jtshouse` core, so they receive the `screentateccw` tag and download under tate/CCW filters:

- `blazer` — Blazer
- `dspirit`, `dspirit2`, `dspirit1` — Dragon Spirit
- `quester`, `questers` — Quester
- `rompers`, `romperso` — Rompers
- `dangseed` — Dangerous Seed

## Why

These titles are natively `vertical (cw)`, so on a CCW-oriented cabinet the `jtshouse` core renders them upside-down by default and they were tagged CW-only (excluded from `screen_tate_ccw`). Each game exposes a **Screen Flip** option in its in-game **Service Mode** that corrects the orientation and **persists** (survives a core switch), so on a CCW setup they can be made to display correctly — which is exactly what `flip=yes` is meant to capture (cf. Ajax, where the flip came from a hardware DIP rather than an OSD rotate).

## Verification

Hardware-tested on a MiSTer Pi with a physically CCW tube. Confirmed the Service-Mode flip works and persists on: **Blazer, Dragon Spirit, Quester, Rompers, Dangerous Seed**. Clones share their parent's service menu / ROM behavior, so they're included on the parent's result.

## Deliberately not included

- `blastoff` (Blast Off) — its Service Mode currently **errors** on the `jtshouse` core, so the flip is unreachable and I couldn't verify it. Will submit separately once that core bug is fixed.
- `puzlclub` (Puzzle Club) — unreleased prototype, not distributed, so unaffected.

Only `ArcadeDatabase.csv` is touched; `mad/` is left for CI to regenerate.