### PR TITLE
Exed Exes: rotation to vertical (ccw) per MAME + flip=yes on both sets

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -551,7 +551,7 @@ eswatj1,"E-Swat - Cyber Police (JP, Set 1)",Japan,"Set 1, FD1094 317-0131",yes,E
 eswatu,"E-Swat - Cyber Police (US, Set 3)",USA,"Set 3, FD1094 317-0129",yes,E-Swat,Sega System 16,,no,no,1989,Sega,Platform - Shooter Scrolling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,3
 europac,Euro Pac [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Stefano Priore,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 exctleag,Excite League (W),World,FD1094 317-0079,no,Excite League,Sega System 16,,no,no,1988,Sega,Sports - Baseball,,15kHz,horizontal,n-a,,2 (simultaneous),,,3
-exedexes,Exed Exes,World,,no,Exed Exes,Capcom CPS-0,,no,no,1985,Capcom,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
+exedexes,Exed Exes,World,,no,Exed Exes,Capcom CPS-0,,no,no,1985,Capcom,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 exeriont,Exerion (Taito),World,,no,Exerion,Jaleco Exerion based,Exerion,no,no,1983,Jaleco (Taito America License),Shooter - Gallery,,15kHz,vertical (cw),,,2 (alternating),8-way,,2
 exprraid,"Express Raider (W, Rev 4)",World,Rev 4,no,Express Raider,Data East Unique,Express Raider,no,no,1986,Data East USA,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 extrmatn,Extermination (W),World,,no,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito Corporation Japan,Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
@@ -1393,7 +1393,7 @@ samesamecn,"Jiao! Jiao! Jiao! (China, 2P set)",China,,yes,Fire Shark,Toaplan 1,,
 sarge,Sarge,World,,no,,Midway MCR3,,no,no,1985,Bally - Midway,Shooter - Field,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,2
 sargex,Sarge Exposed [hb],World,,yes,Sarge,Midway MCR3,,yes,no,1985,Gatinho,Shooter - Field,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,2
 sathena,Super Athena [bl],World,,no,Athena,SNK Triple Z80,,no,yes,1986,SNK,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
-savgbees,Savage Bees,World,,yes,Exed Exes,Capcom CPS-0,,no,no,1985,Capcom,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
+savgbees,Savage Bees,World,,yes,Exed Exes,Capcom CPS-0,,no,no,1985,Capcom,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 sbagman,Super Bagman,World,,no,Super Bagman,Stern based,,no,no,1984,Valadon Automation,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 sbagman2,Super Bagman (Ver 3),World,Ver 3,yes,Super Bagman,Stern based,,no,no,1984,Valadon Automation,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 sbagmans,Super Bagman (Stern),World,Stern,yes,Super Bagman,Stern based,,no,no,1984,Valadon Automation - Stern,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1


### PR DESCRIPTION
## What

Two rows changed:

- **exedexes**: rotation corrected `vertical (cw)` -> `vertical (ccw)`, and `flip` set to `yes`
- **savgbees** (Savage Bees, clone): rotation left at `vertical (ccw)` (unchanged), `flip` set to `yes`

## Why

- **Rotation follows MAME / adb.arcadeitalia.net.** Both sets are ROT270 there (https://adb.arcadeitalia.net/dettaglio_mame.php?game_name=exedexes), i.e. `vertical (ccw)`. The `savgbees` row was already correct at ccw; the `exedexes` row was `vertical (cw)` in the database, which does not match MAME — this PR corrects that pre-existing discrepancy so the parent and clone agree and both follow MAME.
- **flip=yes**: the MiSTer jtexed core's OSD screen flip works (hardware-verified on a rotated CRT), so with `flip=yes` the game downloads and can be displayed right-side-up on both cw and ccw tate setups.

(Note: an earlier revision of this PR set the rotation to `vertical (cw)` to match the core's default boot orientation; that has been corrected — rotation should follow MAME's original-cabinet orientation, not how the core happens to boot.)

Tested on real hardware: the jtbin `Exed Exes.mra` loads and plays correctly, and the OSD flip toggle works.
