### PR TITLE
Add entries for Front Line and Adventure Canoe (Taito System SJ)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2165,9 +2165,11 @@ demonwld1,Demon's World - Horror Story (Set 2),World,Set 2,yes,Demon's World,Toa
 demonwld3,Demon's World - Horror Story (Set 4),World,Set 4,yes,Demon's World,Toaplan 1,Demon's World,no,no,1989,Toaplan,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 demonwld4,Demon's World - Horror Story (Set 5),World,Set 5,yes,Demon's World,Toaplan 1,Demon's World,no,no,1989,Toaplan,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 demonwld5,Demon's World - Horror Story (Set 6),World,Set 6,yes,Demon's World,Toaplan 1,Demon's World,no,no,1989,Toaplan,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
+adcanoe,Adventure Canoe,World,,no,Adventure Canoe,Taito System SJ,Adventure Canoe,no,no,1982,Taito Corporation,,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,2
 alpine,Alpine Ski (Set 1),World,Set 1,no,Alpine Ski,Taito System SJ,Alpine Ski,no,no,1981,Taito,Sports - Skiing,,15kHz,vertical (ccw),,,2 (alternating),2-way horizontal,,1
 bioatack,Bio Attack,World,,no,Bio Attack,Taito System SJ,Bio Attack,no,no,1983,Taito Corporation (Fox Video Games License),Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (alternating),8-way,,1
 elevatorb,Elevator Action [bl],World,bootleg,no,Elevator Action,Taito System SJ,Elevator Action,no,no,1983,bootleg,Platform - Shooter,,15kHz,horizontal,,,2 (alternating),8-way,,2
+frontlin,Front Line,World,,no,Front Line,Taito System SJ,Front Line,no,no,1982,Taito Corporation,Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (alternating),8-way,,2
 hwrace,High Way Race,World,,no,High Way Race,Taito System SJ,High Way Race,no,no,1983,Taito Corporation,Driving - Race,,15kHz,vertical (ccw),,,2 (alternating),8-way,,2
 junglek,Jungle King (JP),Japan,,no,Jungle King,Taito System SJ,Jungle King,no,no,1982,Taito Corporation,"Platform - Run, Jump &amp; Scrolling",,15kHz,horizontal (180),,,2 (alternating),8-way,,1
 piratpet,Pirate Pete,World,,no,Pirate Pete,Taito System SJ,Pirate Pete,no,no,1982,Taito America Corporation,"Platform - Run, Jump &amp; Scrolling",,15kHz,horizontal (180),,,2 (alternating),8-way,,1


### PR DESCRIPTION
Adds MAD rows for two Taito System SJ games that are distributed as MRAs but have no database entry (currently tagged `nomadentrymra`, so they get no screen/control tags and are skipped by orientation filters):

- **frontlin** — Front Line (Taito, 1982). Boots **vertical (ccw)** on the TaitoSJ core; the OSD flip works (applies on reset), so `flip=yes`.
- **adcanoe** — Adventure Canoe (Taito, 1982). Boots **vertical (cw)**; OSD flip + reset displays it correctly on a CCW monitor, so `flip=yes`.

Both hardware-verified on a MiSTer with a vertical CCW CRT. Rows inserted alongside the existing Taito System SJ block, fields modeled on the sibling entries; control data from the MRAs (Front Line: 8-way + 2 buttons with gun-rotate mapped to buttons, special_controls left blank per the ikari precedent; Adventure Canoe: 2-way + 2 buttons).