### PR TITLE
Add Kangaroo core entries (fnkyfish, kangaroo, kangarooa, kangaroob)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -606,6 +606,7 @@ fitegolf,Fighting Golf,World,,no,Fighting Golf,SNK Triple Z80,,no,no,1988,SNK,Sp
 flicky,Flicky (128k Ver),World,"128k Version, 315-5051",no,,Sega System 1,,no,no,1984,Sega,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),2-way horizontal,,1
 flkatck,Flak Attack (JP),Japan,,yes,,Konami 6309 based,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,
 flkatcka,"Flak Attack (JP, PWB 450593 sub-board)",Japan,,yes,,Konami 6309 based,,no,no,1987,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,
+fnkyfish,Funky Fish,World,,no,Funky Fish,Kangaroo hardware,Funky Fish,no,no,1981,Sun Electronics,Shooter - Misc. Vertical,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
 foodf,Food Fight (Rev 3),World,Rev 3,no,,Atari 68000,,no,no,1982,General Computer Corporation - Atari,Fighter - Field,,15kHz,horizontal,,,2 (alternating),8-way,,1
 foodf1,Food Fight (Rev 1),World,Rev 1,yes,Food Fight,Atari 68000,,no,no,1982,General Computer Corporation - Atari,Fighter - Field,,15kHz,horizontal,,,2 (alternating),8-way,,1
 foodf2,Food Fight (Rev 2),World,Rev 2,yes,Food Fight,Atari 68000,,no,no,1982,General Computer Corporation - Atari,Fighter - Field,,15kHz,horizontal,,,2 (alternating),8-way,,1
@@ -855,6 +856,9 @@ kagekij,Kageki (JP),Japan,,yes,Kageki,Taito The NewZealand Story hardware,Kageki
 kaiteids,Kaitei Daisensou (JP),Japan,,yes,In The Hunt,Irem M92,In The Hunt,no,no,1993,Irem,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 kamakazi3,Kamakazi III (Superg) [hb],World,Superg,yes,Scramble,Konami Scramble based,,yes,no,1979,hack,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
 kamikazesp,"Kamikaze (Scramble, ES) [bl]",Spain,"Scramble, Spanish",yes,Scramble,Konami Scramble based,,no,yes,1981,Konami,Shooter - Flying Horizontal,,15kHz,vertical (cw),no,,2 (alternating),4-way,,0
+kangaroo,Kangaroo,World,,no,Kangaroo,Kangaroo hardware,Kangaroo,no,no,1982,Sun Electronics,Platform - Fighter,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+kangarooa,Kangaroo (Atari),USA,,no,Kangaroo,Kangaroo hardware,Kangaroo,no,no,1982,Sun Electronics (Atari license),Platform - Fighter,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+kangaroob,Kangaroo (Bootleg),World,bootleg,no,Kangaroo,Kangaroo hardware,Kangaroo,no,no,1982,bootleg,Platform - Fighter,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 karatedo,Karate Dou (JP),Japan,,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
 karatevs,"Taisen Karate Dou (JP, VS version)",Japan,,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (simultaneous),4-way,,4
 kchamp,Karate Champ (US),USA,,no,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4


### PR DESCRIPTION
The Kangaroo core currently has no MAD entries at all — all four of its distributed MRAs (Funky Fish, Kangaroo, Kangaroo (Atari), Kangaroo (Bootleg)) are tagged `nomadentrymra` and get no screen/control tags, so they never download for users with orientation filters.

This adds rows for all four setnames. All four were hardware-verified on a MiSTer:

- **fnkyfish (Funky Fish)**: boots vertical (cw); the core's OSD flip works → `flip=yes`. (The MRA hints `flip=no`, but the flip does work on hardware.)
- **kangaroo / kangarooa / kangaroob**: boot vertical (cw); the OSD flip options have no effect and there is no flip DIP → `flip=no`.

Notes:
- `kangaroo.zip` in the ROM DB is a merged set, so the Atari and bootleg MRAs load fine from it via their `|kangaroo.zip` fallback.
- Categories: Kangaroo as `Platform - Fighter`, Funky Fish as `Shooter - Misc. Vertical`.