### PR TITLE
Add Boogie Wings / The Great Ragtime Show (Data East, 1992)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -248,6 +248,9 @@ bombjack2,Bomb Jack (Set 2),World,Set 2,yes,Bomb Jack,Tehkan hardware,,no,no,198
 bombjacks01,Bomb Jack (CN) [hb],China,Chinese,yes,Bomb Jack,Tehkan hardware,,yes,no,1984,Tehkan,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),8-way,,1
 bombjckb,Bomb Jack [bl],World,,yes,Bomb Jack,Tehkan hardware,,no,yes,1984,Tehkan,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),8-way,,1
 bombjred,Bomb Jack (Red) [hb],World,Red,yes,Bomb Jack,Tehkan hardware,,yes,no,1984,Tehkan,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),8-way,,1
+boogwing,"Boogie Wings (Euro v1.5, 92.12.07)",Europe,"v1.5, 92.12.07",no,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
+boogwinga,"Boogie Wings (Asia v1.5, 92.12.07)",Asia,"v1.5, 92.12.07",yes,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
+boogwingu,"Boogie Wings (USA v1.7, 92.12.14)",USA,"v1.7, 92.12.14",yes,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 boothill,Boot Hill,World,,no,Boot Hill,Midway 8080,,no,no,1977,Dave Nutting Associates - Midway,Shooter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,1
 bosco,Bosconian - Star Destroyer (New Version),World,,no,Bosconian,Namco Galaga based,Bosconian,no,no,1981,Namco,Shooter - Field,,15kHz,horizontal,,,2 (alternating),8-way,,1
 boscomd,"Bosconian - Star Destroyer (Midway, New Version)",USA,,yes,Bosconian,Namco Galaga based,Bosconian,no,no,1981,Namco,Shooter - Field,,15kHz,horizontal,,,2 (alternating),8-way,,1
@@ -1316,6 +1319,8 @@ quarteta,"Quatret (W, 4 Players)",World,"4 Players, 8751 315-5194",yes,Quatret,S
 radarscp,Radar Scope,World,,no,,Donkey Kong hardware,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,1
 radarscpc,Radar Scope (Rev C),World,,yes,,Donkey Kong hardware,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,1
 raflesia,Rafflesia (315-5162),Japan,315-5162,no,,Sega System 1,,no,no,1986,Sega,Shooter - Flying Vertical,,15kHz,vertical (ccw),no,,2 (alternating),8-way,,2
+ragtime,"The Great Ragtime Show (Japan v1.5, 92.12.07)",Japan,"v1.5, 92.12.07",yes,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
+ragtimea,"The Great Ragtime Show (Japan v1.3, 92.11.26)",Japan,"v1.3, 92.11.26",yes,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 raiders5,Raiders5,World,,no,Raiders5,Taito Unique,Raiders5,no,no,1984,Taito,Maze - Shooter Large,,15kHz,horizontal,,,2 (alternating),2-way horizontal,,2
 rallybik,Rally Bike - Dash Yarou,World,,no,,Toaplan 1,,no,no,1989,Toaplan,Driving - Motorbike,,15kHz,vertical (ccw),,,2 (alternating),8-way,,2
 rallyx,Rally-X (32k Ver),World,32k Ver,no,,Namco Pac-Man hardware,Rally-X,no,no,1980,Namco,Maze - Driving,,15kHz,horizontal,,,2 (alternating),4-way,,1


### PR DESCRIPTION
Adds MAD rows for the new **Arcade-BoogieWings** core (rmonic79), which recently landed in Distribution_MiSTer with its RBF + MRAs but no database entry — so all sets were tagged `nomadentrymra` (no screen/category tags) and got filtered out on screen/tate-filtered setups.

Five sets — `boogwing` (parent) plus alternatives `boogwinga`, `boogwingu`, `ragtime`, `ragtimea`:

- **rotation:** horizontal (MAME and the MRA agree; deco32 hardware)
- **category:** Shooter - Misc. Horizontal (per MAME catver)
- **flip:** blank (horizontal, N/A)
- 2 players simultaneous, 8-way, 2 buttons, 1992, Data East Corporation

Tested on real hardware (DE10-Nano): the Euro parent boots and plays correctly.

Note: `platform` is set to `Data East DE-0379 hardware` as a best guess — `boogwing` is 68000-based (DECO 102 custom, PCB DE-0379-1), not the ARM/156 chips, and there's no existing deco32-family platform string in the DB. Happy to rename to whatever you'd prefer.