### PR TITLE
Bronx: correct rotation to vertical (cw) per MAME

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2485,7 +2485,7 @@ onna34ro,Onna Sanshirou - Typhoon Gal (Rev 1),World,Rev 1,no,,Taito The FairyLan
 onna34roa,Onna Sanshirou - Typhoon Gal [bl],bootleg,bootleg,yes,Onna Sanshirou - Typhoon Gal,Taito The FairyLand Story hardware,,no,yes,1985,Taito,Fighter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,2
 rumba,Rumba Lumber (Rev 1),World,Rev 1,no,,Taito The FairyLand Story hardware,,no,no,1984,Taito,Maze - Collect,,15kHz,vertical (ccw),,,2 (alternating),8-way,,2
 victnine,Victorious Nine,World,,no,,Taito The FairyLand Story hardware,,no,no,1984,Taito,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-bronx,Bronx [bl],bootleg,,yes,Cycle Shooting,Taito N.Y. Captor hardware,,no,no,1986,bootleg,Shooter - Gun,,15kHz,horizontal,,,1,,Lightgun,1
+bronx,Bronx [bl],bootleg,,yes,Cycle Shooting,Taito N.Y. Captor hardware,,no,no,1986,bootleg,Shooter - Gun,,15kHz,vertical (cw),,,1,,Lightgun,1
 juju,JuJu Densetsu (JP),Japan,,no,Toki,Seibu Toki hardware,,no,no,1989,TAD Corporation,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 polaris,Polaris (LV),World,Latest Version,no,,Midway 8080,,no,no,1980,Taito,Shooter - Gallery,,15kHz,vertical (ccw),,,2 (alternating),8-way,,1
 raiga,Raiga - Strato Fighter (JP),Japan,,no,Raiga - Strato Fighter,Tecmo Ninja Gaiden hardware,,no,no,1991,Tecmo,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2


### PR DESCRIPTION
## What

One row changed:

- **bronx** (Bronx, bootleg of Cycle Shooting): rotation corrected `horizontal` -> `vertical (cw)`

## Why

- **Rotation follows MAME / adb.arcadeitalia.net.** Both `bronx` and its parent `cyclshtg` (Cycle Shooting) are **ROT90 = vertical (cw)** in MAME (https://adb.arcadeitalia.net/dettaglio_mame.php?game_name=bronx). The current `horizontal` value is incorrect and was most likely inherited from `nycaptor` (N.Y. Captor), which shares the same Taito hardware but is genuinely horizontal.
- The jtbin MRA for this game also carries `<rotation>vertical (cw)</rotation>`, so it already displays vertically on MiSTer; only the database's screen tag was wrong.
- Verified on real MiSTer hardware (DE10-Nano): the game boots in vertical (cw) orientation.

Rotation only; flip left as-is.
