### PR TITLE
Add Jr. Pac-Man (jrpacman)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -848,6 +848,7 @@ joust2,Joust 2 - Survival of the Fittest (Rev 2),World,Rev. 2,no,Joust 2,William
 joust2r1,Joust 2 - Survival of the Fittest (Rev 1),World,Rev. 1,yes,Joust 2,Williams 2nd Generation,Joust,no,no,1986,Williams,Platform - Run Jump,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,
 joustr,Joust (Solid Red Label),World,Solid Red Label,yes,Joust,Williams 1st Generation,Joust,no,no,1982,Williams,Platform - Run Jump,,15kHz,horizontal,,,2 (simultaneous),2-way horizontal,,1
 joustwr,Joust (White-Red Label),World,White-Red Label,yes,Joust,Williams 1st Generation,Joust,no,no,1982,Williams,Platform - Run Jump,,15kHz,horizontal,,,2 (simultaneous),2-way horizontal,,1
+jrpacman,Jr. Pac-Man,World,,no,Jr. Pac-Man,Namco Pac-Man hardware,Pac-Man,no,no,1983,Bally - Midway,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,0
 jumpshot,Jump Shot,World,,no,Jump Shot,Namco Pac-Man hardware,,no,no,1985,Bally - Midway,Sports - Basketball,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,1
 jumpshotp,Jump Shot (Engineering Sample),World,Engineering Sample,yes,Jump Shot,Namco Pac-Man hardware,,no,no,1985,Bally - Midway,Sports - Basketball,,15kHz,vertical (cw),no,,2 (simultaneous),8-way,,1
 jyangoku,"Jyangokushi- Haoh no Saihai (JP, 990527)",Japan,990527,no,,Capcom CPS-2,,no,no,1999,Capcom,Tabletop - Mahjong,,15kHz,horizontal,n-a,,1,8-way,n-a,2


### PR DESCRIPTION
Adds a MAD row for **Jr. Pac-Man** (`jrpacman`), which runs on the Pacman core (`Jr. Pac-Man.mra` is distributed in Arcade-Pacman_MiSTer's `releases/`). The set had no entry in `ArcadeDatabase.csv`, so it was tagged `nomadentrymra` with no screen tags.

- **rotation** = `vertical (cw)` — MAME/adb.arcadeitalia lists `jrpacman` at 90 deg (cw), matching the MRA's `<rotation>`.
- **flip** = `no` — hardware-tested on a CCW tate CRT: the Pacman core's OSD Flip Screen does **not** yield a clean 180 for this set. Most tiles mirror in place rather than being repositioned (its horizontally-scrolling tilemap is mangled), and a core reset doesn't help. The core's flip works for its other games, but not for Jr. Pac-Man, so `no` is the honest value here.

Other fields follow the sibling Pacman-core rows (Pac-Man, Jump Shot): Bally - Midway, 1983, Maze - Collect, 2 (alternating), 4-way, 0 buttons.