### PR TITLE
Karate Champ family: set flip=yes

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -912,16 +912,16 @@ kamikazesp,"Kamikaze (Scramble, ES) [bl]",Spain,"Scramble, Spanish",yes,Scramble
 kangaroo,Kangaroo,World,,no,Kangaroo,Kangaroo hardware,Kangaroo,no,no,1982,Sun Electronics,Platform - Fighter,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 kangarooa,Kangaroo (Atari),USA,,no,Kangaroo,Kangaroo hardware,Kangaroo,no,no,1982,Sun Electronics (Atari license),Platform - Fighter,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 kangaroob,Kangaroo (Bootleg),World,bootleg,no,Kangaroo,Kangaroo hardware,Kangaroo,no,no,1982,bootleg,Platform - Fighter,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-karatedo,Karate Dou (JP),Japan,,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-karatevs,"Taisen Karate Dou (JP, VS version)",Japan,,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (simultaneous),4-way,,4
-kchamp,Karate Champ (US),USA,,no,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-kchampvs,"Karate Champ (US, VS Ver, Set 1)",USA,Set 1,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-kchampvs2,"Karate Champ (US, VS Ver, Set 2)",USA,Set 2,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-kchampvs3,"Karate Champ (US, VS Ver, Set 3)",USA,Set 3,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-kchampvs4,"Karate Champ (US, VS Ver, Set 4)",USA,Set 4,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-karateda,Karate Dou (Arfyc) [bl],bootleg,Arfyc,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-kchamptec,Karate Champ (Tecfri) [bl],bootleg,Tecfri,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
-kchamp2p,"Karate Champ (US, 2P)",USA,2P,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),,,2 (alternating),4-way,,4
+karatedo,Karate Dou (JP),Japan,,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+karatevs,"Taisen Karate Dou (JP, VS version)",Japan,,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (simultaneous),4-way,,4
+kchamp,Karate Champ (US),USA,,no,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+kchampvs,"Karate Champ (US, VS Ver, Set 1)",USA,Set 1,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+kchampvs2,"Karate Champ (US, VS Ver, Set 2)",USA,Set 2,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+kchampvs3,"Karate Champ (US, VS Ver, Set 3)",USA,Set 3,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+kchampvs4,"Karate Champ (US, VS Ver, Set 4)",USA,Set 4,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+karateda,Karate Dou (Arfyc) [bl],bootleg,Arfyc,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+kchamptec,Karate Champ (Tecfri) [bl],bootleg,Tecfri,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
+kchamp2p,"Karate Champ (US, 2P)",USA,2P,yes,Karate Champ,Data East Z80 based,Karate Champ,no,no,1984,Data East,Fighter - Versus,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,4
 ket,Ketsui - Kizuna Jigoku Tachi (2003.01.01. Master Ver.),Japan,2003.01.01. Master Ver.,no,Ketsui - Kizuna Jigoku Tachi,IGS PGM,,no,no,2002,CAVE,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
 kick,Kick,World,,no,,Midway MCR1,,no,no,1980,Midway,Ball &amp; Paddle - Jump and Touch,,15kHz,vertical (cw),no,,1,,trackball,1
 kickc,Kick (Cocktail),World,Cocktail,yes,Kick,Midway MCR,,no,no,1981,Midway,Ball &amp; Paddle - Jump and Touch,,15kHz,vertical (cw),no,,1,2-way horizontal,,0


### PR DESCRIPTION
Sets `flip=yes` on the 10 Karate Champ family rows (jotego `jtkchamp` core). Rotation is untouched.

All 10 sets are `vertical (cw)` — confirmed ROT90 in MAME / adb.arcadeitalia — with the `flip` field previously blank. The core has a working, persistent core-level screen flip (`JTFRAME_OSD_FLIP`), so on a CCW-rotated tate CRT the image can be flipped right-side-up and stays that way. With `flip=yes` these rows gain the `screentateccw` tag and download under a CCW-tate screen filter, matching the many CW-native jotego titles already carrying flip=yes.

**Hardware-tested** on a real DE10/MiSTer CCW tate CRT: `kchamp` (single-player) and `kchampvs` (VS) both boot CW and flip cleanly to right-side-up via the core's OSD Flip. The flip is ROM-agnostic (applied by the framework after render), so it covers the clones/bootlegs on the same core.

Rows changed: `kchamp`, `kchampvs`, `kchampvs2`, `kchampvs3`, `kchampvs4`, `karatevs`, `karatedo`, `karateda`, `kchamptec`, `kchamp2p`.

Diff is flip-only: 10 additions / 10 deletions, `ArcadeDatabase.csv` only.