### PR TITLE
Set flip=yes on Lethal Thunder / Thunder Blaster (IremM92)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -973,7 +973,7 @@ ldruna,Lode Runner (Set 2),World,Set 2,yes,Lode Runner,Irem M62,Lode Runner,no,n
 leaguemn,Yakyuu Kakutou League-Man (JP),Japan,,yes,Ninja Baseball Bat Man,Irem M92,Ninja Baseball Bat Man,no,no,1993,Irem,Fighter - 2.5D,,15kHz,horizontal,,,4 (simultaneous),8-way,,2
 legion,"Legion - Spinner-87 (W, ver 2.03)",World,,yes,Chouji Meikyuu Legion,Nichibutsu M68000 (Armed F),,no,no,1987,Nichibutsu,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 legionj2,"Chouji Meikyuu Legion (JP, ver 1.05, Set 2)",Japan,,no,Chouji Meikyuu Legion,Nichibutsu M68000 (Armed F),,no,no,1987,Nichibutsu,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
-lethalth,Lethal Thunder (W),World,,no,Lethal Thunder,Irem M92,Lethal Thunder,no,no,1992,Irem,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
+lethalth,Lethal Thunder (W),World,,no,Lethal Thunder,Irem M92,Lethal Thunder,no,no,1992,Irem,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 lizwiz,Lizard Wizard,World,,no,,Namco Pac-Man hardware,,no,no,1985,Techstar - Sunn,Shooter - Field,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,1
 llander,Lunar Lander (Rev 2),World,Rev 2,no,,Atari 6502,,no,no,1979,Atari,Driving - Landing,,31kHz,horizontal,,,1,2-way horizontal,,1
 llander1,Lunar Lander (Rev 1),World,Rev 1,yes,Lunar Lander,Atari 6502,,no,no,1979,Atari,Driving - Landing,,31kHz,horizontal,,,1,2-way horizontal,,1
@@ -1831,7 +1831,7 @@ theends,The End (Stern),World,Stern,yes,The End,Konami Scramble based,,no,no,198
 theglad,The Gladiator (ver. 107),World,ver. 107,no,The Gladiator,IGS PGM,,no,no,2003,IGS,Fighter - 2.5D,,15kHz,horizontal,,,2-4 (simultaneous),8-way,,4
 theglobp,The Glob (Pac-Man Hardware),World,Pac-Man Hardware,no,,Namco Pac-Man hardware,,no,no,1983,Epos Corporation,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,2
 theroes,Thunder Heroes,World,,no,Thunder Heroes,CAVE 68000,,no,no,2001,CAVE,Fighter - 2.5D,,15kHz,horizontal,no,,2 (simultaneous),8-way,,4
-thndblst,Thunder Blaster (JP),Japan,,yes,Lethal Thunder,Irem M92,Lethal Thunder,no,no,1992,Irem,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
+thndblst,Thunder Blaster (JP),Japan,,yes,Lethal Thunder,Irem M92,Lethal Thunder,no,no,1992,Irem,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 tigerhb1,Tiger Heli [bl],World,,no,Tiger Heli,Toaplan Slap Fight hardware,Tiger Heli,no,no,1985,Toaplan - Taito,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (alternating),8-way,,2
 tigeroad,Tiger Road,World,,no,Tiger Road,Capcom CPS-0,,no,no,1987,Capcom,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 tigeroadu,"Tiger Road (US, Romstar)",USA,Romstar,yes,Tiger Road,Capcom CPS-0,,no,no,1987,Capcom - Romstar,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2


### PR DESCRIPTION
`lethalth` (Lethal Thunder) and its clone `thndblst` (Thunder Blaster) run on the **IremM92** core and are `vertical (ccw)` with flip blank. The IremM92 core has a working screen flip, hardware-verified on a CCW-rotated tate CRT (Lethal Thunder boots and the flip produces a persistent, correct 180°). Thunder Blaster is a true clone sharing the same video hardware, so it rides the same result.

Setting flip=yes on both rows. Rotation is unchanged — MAME/adb.arcadeitalia has both at ROT270 = `vertical (ccw)`, matching the existing rows and the distributed MRAs. Diff is CSV-only, 2 insertions / 2 deletions.