### PR TITLE
Naughty Boy: set flip=yes (jaleco naughtyb)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2727,5 +2727,5 @@ qtorimon,Quiz Torimonochou (JP),Japan,,no,,Taito F2 System,,no,no,1990,Taito Cor
 thundfox,"Thunder Fox (W, Rev 1)",World,Rev 1,no,,Taito F2 System,,no,no,1990,Taito Corporation Japan,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 thundfoxj,"Thunder Fox (JP, Rev 1)",Japan,Rev 1,yes,Thunder Fox,Taito F2 System,,no,no,1990,Taito Corporation,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 thundfoxu,"Thunder Fox (US, Rev 1)",USA,Rev 1,yes,Thunder Fox,Taito F2 System,,no,no,1990,Taito America Corporation,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
-naughtyb,Naughty Boy,World,,no,,Jaleco Naughty Boy hardware,,no,no,1982,Jaleco,Maze - Shooter Large,,15kHz,vertical (cw),,,2 (alternating),4-way,,1
+naughtyb,Naughty Boy,World,,no,,Jaleco Naughty Boy hardware,,no,no,1982,Jaleco,Maze - Shooter Large,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
 popflamn,Pop Flamer [bl],bootleg,bootleg on Naughty Boy PCB,no,,Jaleco Naughty Boy hardware,,no,yes,1982,Jaleco,Maze - Shooter Small,,15 kHz,vertical (cw),,,2 (alternating),4-way,,1


### PR DESCRIPTION
Naughty Boy (`naughtyb`, Jaleco Naughty Boy hardware, MiSTer-devel Arcade-NaughtyBoy core) is `vertical (cw)` with flip left blank, so it gets `screentatecwnoflip` and is excluded from CCW-tate setups even though the core can correct it.

The core has a working OSD **Flip Screen** toggle (`OF,Flip Screen,Off,On;` → the game's screen flip). Hardware-tested on a CCW-rotated CRT: boots CW by default and the OSD flip brings it persistently right-side-up. The distributed MRA also carries `<flip>yes</flip>`.

Rotation is unchanged (MAME/arcadeitalia `naughtyb` = ROT90 = cw, matches the row). This only sets `flip` blank → `yes`.

Note: the sibling `popflamn` (Pop Flamer bootleg, same PCB/core) is also `vertical (cw)` flip-blank and likely the same, but I have not hardware-tested it yet — leaving it for a separate change.