### PR TITLE
Wrestle War: correct rotation to vertical (ccw)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2038,9 +2038,9 @@ wofch,"Tenchi wo Kurau II- Sekiheki no Tatakai (JP, CPS Changer, 921031)",Japan,
 wonder3,"Wonder 3 (JP, 910520)",Japan,910520,yes,Three Wonders,Capcom CPS-1,,no,no,1991,Capcom,MultiGame - Compilation,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
 woodpeck,Woodpecker (Set 1),World,Set 1,no,,Namco Pac-Man hardware,,no,no,1981,Amenip - Palcom Queen River,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
 wow,Wizard of Wor,World,,no,,Midway Astrocade,,no,no,1980,Dave Nutting Associates - Midway,Maze - Shooter Small,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
-wrestwar,"Wrestle War (W, Set 3)",World,Set 3,no,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
-wrestwar1,"Wrestle War (JP, Set 1)",Japan,Set 1,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
-wrestwar2,"Wrestle War (W, Set 2)",World,Set 2,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
+wrestwar,"Wrestle War (W, Set 3)",World,Set 3,no,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,vertical (ccw),n-a,,2 (simultaneous),8-way,,2
+wrestwar1,"Wrestle War (JP, Set 1)",Japan,Set 1,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,vertical (ccw),n-a,,2 (simultaneous),8-way,,2
+wrestwar2,"Wrestle War (W, Set 2)",World,Set 2,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,vertical (ccw),n-a,,2 (simultaneous),8-way,,2
 xensad,Xens Revenge After Dark [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,,yes,no,1980,Jeff Morris,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 xensrev,Xens Revenge [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,,yes,no,1980,Jeff Morris,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 xeviblk,Xevious Black [hb],World,,yes,Xevious,Namco Galaga based,,yes,no,1982,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),no,,2 (alternating),8-way,,2


### PR DESCRIPTION
`wrestwar`, `wrestwar1`, `wrestwar2` were tagged `horizontal`, but Wrestle War runs on a **vertical** monitor.

- MAME / adb.arcadeitalia list `wrestwar` (parent of all three) at **ROT270 = vertical (ccw)**.
- The distributed jts16b MRA already declares `<rotation>vertical (ccw)</rotation>` — the DB row simply contradicts it.
- Hardware-tested on a MiSTer (jts16b core) driving a CCW-rotated CRT: **boots right-side-up**. No screen-flip option on the core, so `flip` left unchanged.

Rotation-only change to 3 rows.