### PR TITLE
Shienryu: correct rotation to vertical (ccw)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2675,7 +2675,7 @@ sandor,Puzzle &amp; Action - Sando-R (JP),Japan,951114 V1.000,no,,Sega ST-V,Puzz
 rsgun,Radiant Silvergun (JUET),World,980523 V1.000,no,,Sega ST-V,Radiant Silvergun,no,no,1998,Treasure,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 seabass,Sea Bass Fishing (JUET),World,971110 V0.001,no,,Sega ST-V,,no,no,1997,A wave inc. (Able License),Sports - Fishing,,15kHz,horizontal,,,1,8-way,,4
 shanhigw,Shanghai - The Great Wall - Shanghai Triple Threat (JUE),World,950623 V1.005,no,,Sega ST-V,Shanghai,no,no,1995,Sunsoft - Activision,Tabletop - Shanghai,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-shienryu,Shienryu (JUET),World,961226 V1.000,no,,Sega ST-V,,no,no,1997,Warashi,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+shienryu,Shienryu (JUET),World,961226 V1.000,no,,Sega ST-V,,no,no,1997,Warashi,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,4
 sokyugrt,Soukyugurentai - Terra Diver (JUET),World,960821 V1.000,no,,Sega ST-V,,no,no,1996,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 sss,Steep Slope Sliders (JUET),World,981110 V1.000,no,,Sega ST-V,,no,no,1998,Capcom - Cave - Victor Interactive Software,Sports - Skiing,,15kHz,horizontal,,,1,8-way,,4
 suikoenb,Suiko Enbu - Outlaws of the Lost Dynasty (JUETL),World,950314 V2.001,no,,Sega ST-V,,no,no,1995,Data East Corporation,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6


### PR DESCRIPTION
The `shienryu` row was tagged `horizontal` (the ST-V platform default), but Shienryu is one of the few ST-V titles that shipped on a **rotated vertical** monitor.

- MAME / adb.arcadeitalia list `shienryu` at **ROT270 = vertical (ccw)**.
- The distributed Arcade-ST-V MRA already declares `<rotation>vertical (ccw)</rotation>`.
- Hardware-tested on a MiSTer (Arcade-ST-V core) driving a CCW-rotated CRT: **boots right-side-up**. No screen-flip option, so `flip` left blank.

Note: sibling ST-V vertical-*gameplay* shooters (`sokyugrt`, `grdforce`, `rsgun`) are correctly `horizontal` — they used horizontal monitors — so this is a shienryu-only correction.

Rotation-only change to 1 row.