### PR TITLE
Fix Sega ST-V name fields to match distributed MRA filenames

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2645,49 +2645,49 @@ starforc,Star Force,World,,no,,Tecmo Senjyo hardware,Star Force,no,no,1984,Tehka
 baluba,Baluba-louk no Densetsu (JP),Japan,,no,,Tecmo Senjyo hardware,,no,no,1986,"Able Corp, Ltd",Platform - Run Jump,,15kHz,vertical (cw),,,2 (alternating),8-way,,1
 megaforc,Mega Force (W),World,,no,Star Force,Tecmo Senjyo hardware,Star Force,no,no,1984,Tehkan,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,1
 megaforcu,Mega Force (US),USA,,yes,Star Force,Tecmo Senjyo hardware,Star Force,no,no,1984,Tehkan,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (alternating),8-way,,1
-astrass,Astra SuperStars (JP),Japan,980514 V1.002,no,,Sega ST-V,,no,no,1998,Sunsoft,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-bakubaku,Baku Baku Animal (JP),Japan,950407 V1.000,no,,Sega ST-V,,no,no,1995,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-batmanfr,Batman Forever (JUE),World,960507 V1.000,no,,Sega ST-V,,no,no,1996,Acclaim,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
-colmns97,Columns '97 (JET),World,961209 V1.000,no,,Sega ST-V,Columns,no,no,1996,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-cotton2,Cotton 2 (JUET),World,970902 V1.000,no,,Sega ST-V,Cotton,no,no,1997,Success,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-cottonbm,Cotton Boomerang (JUET),World,980709 V1.000,no,,Sega ST-V,Cotton,no,no,1998,Success,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-danchih,Danchi de Hanafuda (JP),Japan,990607 V1.400,no,,Sega ST-V,,no,no,1999,Altron (Tecmo License),Tabletop - Hanafuda,,15kHz,horizontal,,,1,8-way,mahjong,20
-danchiq,Danchi de Quiz - Okusan Yontaku Desuyo! (JP),Japan,001128 V1.200,no,,Sega ST-V,,no,no,2000,Altron,Quiz - Questions in Japanese,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-decathlt,Decathlete (JUET),World,960709 V1.001,no,,Sega ST-V,,no,no,1996,Sega,Sports - Track &amp; Field,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-diehard,Die Hard Arcade (UET),World,960515 V1.000,no,,Sega ST-V,Dynamite Deka,no,no,1996,Sega,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-ejihon,Ejihon Tantei Jimusho (JP),Japan,950613 V1.000,no,,Sega ST-V,,no,no,1995,Sega,Puzzle - Misc.,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-ffreveng,Final Fight Revenge - Final Revenge (JUET),World,990930 V1.100,no,,Sega ST-V,Final Fight,no,no,1999,Capcom,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-findlove,Zenkoku Seifuku Bishoujo Grand Prix Find Love (JP),Japan,971212 V1.000,no,,Sega ST-V,,no,no,1997,Daiki - FCF,Puzzle - Reconstruction,,15kHz,horizontal,,,1,8-way,,4
-fhboxers,Funky Head Boxers (JUETBKAL),World,951218 V1.000,no,,Sega ST-V,,no,no,1995,Sega,Sports - Boxing,,15kHz,horizontal,,,1,8-way,,4
-gaxeduel,Golden Axe - The Duel (JUETL),World,950117 V1.000,no,,Sega ST-V,Golden Axe,no,no,1994,Sega,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-groovef,Groove on Fight - Gouketsuji Ichizoku 3 (JP),Japan,970416 V1.001,no,,Sega ST-V,Power Instinct,no,no,1997,Atlus,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-grdforce,Guardian Force (JUET),World,980318 V0.105,no,,Sega ST-V,,no,no,1998,Success,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-hanagumi,Sakura Taisen - Hanagumi Taisen Columns (JP),Japan,971007 V1.010,no,,Sega ST-V,Columns,no,no,1997,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-introdon,Karaoke Quiz Intro Don Don! (JP),Japan,960213 V1.000,no,,Sega ST-V,,no,no,1996,Sunsoft - Success,Quiz - Questions in Japanese,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-maruchan,Maru-Chan de Goo! (JP),Japan,971216 V1.000,no,,Sega ST-V,,no,no,1997,Sega - Toyosuisan,Multiplay - Mini-Games,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-mausuke,Mausuke no Ojama the World (JP),Japan,960314 V1.000,no,,Sega ST-V,,no,no,1996,Data East Corporation,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-othellos,Othello Shiyouyo (JP),Japan,980423 V1.002,no,,Sega ST-V,Othello,no,no,1998,Success,Tabletop - Othello - Reversi,,15kHz,horizontal,,,1,8-way,,4
-pblbeach,Pebble Beach - The Great Shot (JUE),World,950913 V0.990,no,,Sega ST-V,,no,no,1995,T&amp;E Soft,Sports - Golf,,15kHz,horizontal,,,2 (alternating),8-way,,4
-prikura,Princess Clara Daisakusen (JP),Japan,960910 V1.000,no,,Sega ST-V,,no,no,1996,Atlus,Maze - Shooter Large,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-kiwames,Pro Mahjong Kiwame S (JP),Japan,951020 V1.208,no,,Sega ST-V,Pro Mahjong Kiwame,no,no,1995,Athena,Tabletop - Mahjong,,15kHz,horizontal,,,1,8-way,mahjong,20
-puyosun,Puyo Puyo Sun (JP),Japan,961115 V0.001,no,,Sega ST-V,Puyo Puyo,no,no,1996,Compile,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-sandor,Puzzle &amp; Action - Sando-R (JP),Japan,951114 V1.000,no,,Sega ST-V,Puzzle &amp; Action,no,no,1995,Sega,Multiplay - Mini-Games,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-rsgun,Radiant Silvergun (JUET),World,980523 V1.000,no,,Sega ST-V,Radiant Silvergun,no,no,1998,Treasure,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-seabass,Sea Bass Fishing (JUET),World,971110 V0.001,no,,Sega ST-V,,no,no,1997,A wave inc. (Able License),Sports - Fishing,,15kHz,horizontal,,,1,8-way,,4
-shanhigw,Shanghai - The Great Wall - Shanghai Triple Threat (JUE),World,950623 V1.005,no,,Sega ST-V,Shanghai,no,no,1995,Sunsoft - Activision,Tabletop - Shanghai,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-shienryu,Shienryu (JUET),World,961226 V1.000,no,,Sega ST-V,,no,no,1997,Warashi,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-sokyugrt,Soukyugurentai - Terra Diver (JUET),World,960821 V1.000,no,,Sega ST-V,,no,no,1996,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-sss,Steep Slope Sliders (JUET),World,981110 V1.000,no,,Sega ST-V,,no,no,1998,Capcom - Cave - Victor Interactive Software,Sports - Skiing,,15kHz,horizontal,,,1,8-way,,4
-suikoenb,Suiko Enbu - Outlaws of the Lost Dynasty (JUETL),World,950314 V2.001,no,,Sega ST-V,,no,no,1995,Data East Corporation,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-smleague,Super Major League (US),USA,960108 V1.000,no,,Sega ST-V,Major League,no,no,1995,Sega,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-sasissu,Taisen Tanto-R Sashissu!! (JP),Japan,980216 V1.000,no,,Sega ST-V,,no,no,1998,Sega,Multiplay - Mini-Games,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-twcup98,Tecmo World Cup '98 (JUET),World,980410 V1.000,no,,Sega ST-V,Tecmo World Cup,no,no,1998,Tecmo,Sports - Soccer,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-elandore,Touryuu Densetsu Elan-Doree - Elan Doree - Legend of Dragoon (JUET),World,980922 V1.006,no,,Sega ST-V,,no,no,1998,Sai-Mate,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
-vfkids,Virtua Fighter Kids (JUET),World,960319 V0.000,no,,Sega ST-V,Virtua Fighter,no,no,1996,Sega,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-vfremix,Virtua Fighter Remix (JUETBKAL),World,950428 V1.000,no,,Sega ST-V,Virtua Fighter,no,no,1995,Sega,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-myfairld,Virtual Mahjong 2 - My Fair Lady (JP),Japan,980608 V1.000,no,,Sega ST-V,Virtual Mahjong,no,no,1998,Micronet,Tabletop - Mahjong,,15kHz,horizontal,,,1,8-way,mahjong,20
-winterht,Winter Heat (JUET),World,971012 V1.000,no,,Sega ST-V,,no,no,1997,Sega,Sports - Skiing,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
-znpwfv,Zen Nippon Pro-Wres Featuring Virtua (JP),Japan,971123 V1.000,no,,Sega ST-V,All Japan Pro Wrestling,no,no,1997,Sega,Sports - Wrestling,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+astrass,Astra SuperStars (J 980514 V1.002),Japan,980514 V1.002,no,,Sega ST-V,,no,no,1998,Sunsoft,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
+bakubaku,Baku Baku Animal (J 950407 V1.000),Japan,950407 V1.000,no,,Sega ST-V,,no,no,1995,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+batmanfr,Batman Forever (JUE 960507 V1.000),World,960507 V1.000,no,,Sega ST-V,,no,no,1996,Acclaim,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
+colmns97,Columns '97 (JET 961209 V1.000),World,961209 V1.000,no,,Sega ST-V,Columns,no,no,1996,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+cotton2,Cotton 2 (JUET 970902 V1.000),World,970902 V1.000,no,,Sega ST-V,Cotton,no,no,1997,Success,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+cottonbm,Cotton Boomerang (JUET 980709 V1.000),World,980709 V1.000,no,,Sega ST-V,Cotton,no,no,1998,Success,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+danchih,Danchi de Hanafuda (J 990607 V1.400),Japan,990607 V1.400,no,,Sega ST-V,,no,no,1999,Altron (Tecmo License),Tabletop - Hanafuda,,15kHz,horizontal,,,1,8-way,mahjong,20
+danchiq,Danchi de Quiz Okusan Yontaku Desuyo! (J 001128 V1.200),Japan,001128 V1.200,no,,Sega ST-V,,no,no,2000,Altron,Quiz - Questions in Japanese,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+decathlt,Decathlete (JUET 960709 V1.001),World,960709 V1.001,no,,Sega ST-V,,no,no,1996,Sega,Sports - Track &amp; Field,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+diehard,Die Hard Arcade (UET 960515 V1.000),World,960515 V1.000,no,,Sega ST-V,Dynamite Deka,no,no,1996,Sega,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+ejihon,Ejihon Tantei Jimusyo (J 950613 V1.000),Japan,950613 V1.000,no,,Sega ST-V,,no,no,1995,Sega,Puzzle - Misc.,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+ffreveng,Final Fight Revenge - Final Revenge (JUET 990930 V1.100),World,990930 V1.100,no,,Sega ST-V,Final Fight,no,no,1999,Capcom,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
+findlove,Find Love (J 971212 V1.000),Japan,971212 V1.000,no,,Sega ST-V,,no,no,1997,Daiki - FCF,Puzzle - Reconstruction,,15kHz,horizontal,,,1,8-way,,4
+fhboxers,Funky Head Boxers (JUETBKAL 951218 V1.000),World,951218 V1.000,no,,Sega ST-V,,no,no,1995,Sega,Sports - Boxing,,15kHz,horizontal,,,1,8-way,,4
+gaxeduel,Golden Axe - The Duel (JUETL 950117 V1.000),World,950117 V1.000,no,,Sega ST-V,Golden Axe,no,no,1994,Sega,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
+groovef,Groove on Fight - Gouketsuji Ichizoku 3 (J 970416 V1.001),Japan,970416 V1.001,no,,Sega ST-V,Power Instinct,no,no,1997,Atlus,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
+grdforce,Guardian Force (JUET 980318 V0.105),World,980318 V0.105,no,,Sega ST-V,,no,no,1998,Success,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+hanagumi,Hanagumi Taisen Columns - Sakura Wars (J 971007 V1.010),Japan,971007 V1.010,no,,Sega ST-V,Columns,no,no,1997,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+introdon,Karaoke Quiz Intro Don Don! (J 960213 V1.000),Japan,960213 V1.000,no,,Sega ST-V,,no,no,1996,Sunsoft - Success,Quiz - Questions in Japanese,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+maruchan,Maru-Chan de Goo! (J 971216 V1.000),Japan,971216 V1.000,no,,Sega ST-V,,no,no,1997,Sega - Toyosuisan,Multiplay - Mini-Games,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+mausuke,Mausuke no Ojama the World (J 960314 V1.000),Japan,960314 V1.000,no,,Sega ST-V,,no,no,1996,Data East Corporation,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+othellos,Othello Shiyouyo (J 980423 V1.002),Japan,980423 V1.002,no,,Sega ST-V,Othello,no,no,1998,Success,Tabletop - Othello - Reversi,,15kHz,horizontal,,,1,8-way,,4
+pblbeach,Pebble Beach - The Great Shot (JUE 950913 V0.990),World,950913 V0.990,no,,Sega ST-V,,no,no,1995,T&amp;E Soft,Sports - Golf,,15kHz,horizontal,,,2 (alternating),8-way,,4
+prikura,Princess Clara Daisakusen (J 960910 V1.000),Japan,960910 V1.000,no,,Sega ST-V,,no,no,1996,Atlus,Maze - Shooter Large,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+kiwames,Pro Mahjong Kiwame S (J 951020 V1.208),Japan,951020 V1.208,no,,Sega ST-V,Pro Mahjong Kiwame,no,no,1995,Athena,Tabletop - Mahjong,,15kHz,horizontal,,,1,8-way,mahjong,20
+puyosun,Puyo Puyo Sun (J 961115 V0.001),Japan,961115 V0.001,no,,Sega ST-V,Puyo Puyo,no,no,1996,Compile,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+sandor,Puzzle &amp; Action- Sando-R (J 951114 V1.000),Japan,951114 V1.000,no,,Sega ST-V,Puzzle &amp; Action,no,no,1995,Sega,Multiplay - Mini-Games,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+rsgun,Radiant Silvergun (JUET 980523 V1.000),World,980523 V1.000,no,,Sega ST-V,Radiant Silvergun,no,no,1998,Treasure,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+seabass,Sea Bass Fishing (JUET 971110 V0.001),World,971110 V0.001,no,,Sega ST-V,,no,no,1997,A wave inc. (Able License),Sports - Fishing,,15kHz,horizontal,,,1,8-way,,4
+shanhigw,Shanghai - The Great Wall - Shanghai Triple Threat (JUE 950623 V1.005),World,950623 V1.005,no,,Sega ST-V,Shanghai,no,no,1995,Sunsoft - Activision,Tabletop - Shanghai,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+shienryu,Shienryu (JUET 961226 V1.000),World,961226 V1.000,no,,Sega ST-V,,no,no,1997,Warashi,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+sokyugrt,Soukyugurentai - Terra Diver (JUET 960821 V1.000),World,960821 V1.000,no,,Sega ST-V,,no,no,1996,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+sss,Steep Slope Sliders (JUET 981110 V1.000),World,981110 V1.000,no,,Sega ST-V,,no,no,1998,Capcom - Cave - Victor Interactive Software,Sports - Skiing,,15kHz,horizontal,,,1,8-way,,4
+suikoenb,Suikoenbu - Outlaws of the Lost Dynasty (JUETL 950314 V2.001),World,950314 V2.001,no,,Sega ST-V,,no,no,1995,Data East Corporation,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
+smleague,Super Major League (U 960108 V1.000),USA,960108 V1.000,no,,Sega ST-V,Major League,no,no,1995,Sega,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+sasissu,Taisen Tanto-R Sashissu!! (J 980216 V1.000),Japan,980216 V1.000,no,,Sega ST-V,,no,no,1998,Sega,Multiplay - Mini-Games,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+twcup98,Tecmo World Cup '98 (JUET 980410 V1.000),World,980410 V1.000,no,,Sega ST-V,Tecmo World Cup,no,no,1998,Tecmo,Sports - Soccer,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+elandore,Touryuu Densetsu Elan-Doree - Elan Doree - Legend of Dragoon (JUET 980922 V1.006),World,980922 V1.006,no,,Sega ST-V,,no,no,1998,Sai-Mate,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
+vfkids,Virtua Fighter Kids (JUET 960319 V0.000),World,960319 V0.000,no,,Sega ST-V,Virtua Fighter,no,no,1996,Sega,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+vfremix,Virtua Fighter Remix (JUETBKAL 950428 V1.000),World,950428 V1.000,no,,Sega ST-V,Virtua Fighter,no,no,1995,Sega,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+myfairld,Virtual Mahjong 2 - My Fair Lady (J 980608 V1.000),Japan,980608 V1.000,no,,Sega ST-V,Virtual Mahjong,no,no,1998,Micronet,Tabletop - Mahjong,,15kHz,horizontal,,,1,8-way,mahjong,20
+winterht,Winter Heat (JUET 971012 V1.000),World,971012 V1.000,no,,Sega ST-V,,no,no,1997,Sega,Sports - Skiing,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
+znpwfv,Zen Nippon Pro-Wrestling Featuring Virtua (J 971123 V1.000),Japan,971123 V1.000,no,,Sega ST-V,All Japan Pro Wrestling,no,no,1997,Sega,Sports - Wrestling,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 deadconx,Dead Connection (W),World,,no,,Taito F2 System,,no,no,1992,Taito Corporation Japan,Shooter - Field,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 deadconxj,Dead Connection (JP),Japan,,yes,Dead Connection,Taito F2 System,,no,no,1992,Taito Corporation,Shooter - Field,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 metalb,Metal Black (W),World,,no,,Taito F2 System,Gun &amp; Frontier,no,no,1991,Taito Corporation Japan,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,3


### PR DESCRIPTION
The entire Sega ST-V block uses truncated `name` values carrying only the region letters — e.g. `Shienryu (JUET)` — instead of the full MRA filename shipped by the ST-V core, e.g. `Shienryu (JUET 961226 V1.000).mra`.

The `name` field is the key that joins a MAD row to its distributed MRA. Because every ST-V row's name is truncated, none of them match a shipped MRA.

This aligns the ST-V block with the rest of the database, where the `name` field already equals the full MRA filename (e.g. `Pac-Man (Midway)`, `Galaga (Namco Rev. B)`).

Each row's `name` is set to the exact MRA filename (minus `.mra`) as shipped in the ST-V core's `releases/mra`. This also corrects a few names that were not just truncated but differed from the shipped file (e.g. `Zenkoku Seifuku Bishoujo Grand Prix Find Love` → `Find Love`, `Sakura Taisen - Hanagumi Taisen Columns` → `Hanagumi Taisen Columns - Sakura Wars`, `Ejihon Tantei Jimusho` → `Jimusyo`, `Zen Nippon Pro-Wres` → `Pro-Wrestling`).

Name field only — 43 rows changed, no rotation or other fields touched.