### PR TITLE
Add Planet Probe (pprobe) — missing MAD entry (Vastar core)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -1338,6 +1338,7 @@ powa,"P.O.W. - Prisoners of War (US, Version 1, Mask ROM Sprites)",USA,,yes,P.O.
 powerdrv,Power Drive,World,,no,,Midway MCR3,,no,no,1986,Bally - Midway,Driving - Race,,15kHz,horizontal,,,3 (simultaneous),4-way,,1
 powj,Datsugoku - Prisoners of War (JP),Japan,,yes,P.O.W. Prisoners of War,SNK 68000,P.O.W. Prisoners of War,no,no,1988,SNK,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 pplusad,Pacman Plus After Dark [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Bally - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
+pprobe,Planet Probe,World,,no,Planet Probe,Vastar hardware,,no,no,1985,Crux / Kyugo?,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),4-way,,2
 prehisle,Prehistoric Isle in 1930 (W),World,,no,Prehistoric Isle,SNK Unique,Prehistoric Isle,no,no,1989,SNK,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 prehislek,Wonsido 1930's (KR),Korea,,yes,Prehistoric Isle,SNK Unique,Prehistoric Isle,no,no,1989,SNK,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 prehisleu,Prehistoric Isle in 1930 (US),USA,,yes,Prehistoric Isle,SNK Unique,Prehistoric Isle,no,no,1989,SNK,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2


### PR DESCRIPTION
Adds a row for **Planet Probe** (`pprobe`, prototype, 1985), which runs on the **Vastar** core (`<rbf>Vastar</rbf>`, distributed as `_Arcade/Planet Probe.mra`). It currently has no MAD entry, so it is tagged `nomadentrymra` with no screen tags.

Field sources:
- **rotation `vertical (cw)`** — MAME `vastar.cpp`: `pprobe` is `ROT90` (adb.arcadeitalia confirms; original cabinet is CW). The distributed MRA mislabels this as `vertical (ccw)` — a companion PR to Arcade-Vastar_MiSTer corrects the MRA `<rotation>`.
- **flip `no`** — hardware-tested on a real CCW-tate CRT: the Vastar core has no working screen flip (no OSD/DIP/service-menu 180°). So this stays CW-only; the row is for catalog/metadata completeness, not a CCW-tate download enabler.
- region/players/joystick/buttons/year from the MRA + MAME; `manufacturer` = MAME's `Crux / Kyugo?`; `category` = `Shooter - Gallery` (MAME catver genre "Shooter / Gallery").
- **`platform` = `Vastar hardware`** — coined (no prior Vastar platform string exists); adjust if you prefer a different normalization.

Diff is a single added row, alphabetically placed between `pplusad` and `prehisle`.