### PR TITLE
Pop Flamer: set flip=yes + fix name to match distributed MRA

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2728,4 +2728,4 @@ thundfox,"Thunder Fox (W, Rev 1)",World,Rev 1,no,,Taito F2 System,,no,no,1990,Ta
 thundfoxj,"Thunder Fox (JP, Rev 1)",Japan,Rev 1,yes,Thunder Fox,Taito F2 System,,no,no,1990,Taito Corporation,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 thundfoxu,"Thunder Fox (US, Rev 1)",USA,Rev 1,yes,Thunder Fox,Taito F2 System,,no,no,1990,Taito America Corporation,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 naughtyb,Naughty Boy,World,,no,,Jaleco Naughty Boy hardware,,no,no,1982,Jaleco,Maze - Shooter Large,,15kHz,vertical (cw),,,2 (alternating),4-way,,1
-popflamn,Pop Flamer [bl],bootleg,bootleg on Naughty Boy PCB,no,,Jaleco Naughty Boy hardware,,no,yes,1982,Jaleco,Maze - Shooter Small,,15 kHz,vertical (cw),,,2 (alternating),4-way,,1
+popflamn,Pop Flamer (Bootleg conversion),bootleg,bootleg on Naughty Boy PCB,no,,Jaleco Naughty Boy hardware,,no,yes,1982,Jaleco,Maze - Shooter Small,,15 kHz,vertical (cw),yes,,2 (alternating),4-way,,1


### PR DESCRIPTION
## popflamn (Pop Flamer) — Arcade-NaughtyBoy core

Follow-up to #77 (Naughty Boy), same core/platform (`Jaleco Naughty Boy hardware`). Two fixes to the single `popflamn` row:

**1. flip (blank → yes).** The Arcade-NaughtyBoy core has a working OSD Flip Screen (verified for Naughty Boy in #77). Pop Flamer is a distinct game (bootleg on the same Naughty Boy PCB) so it was tested on its own: booted on a real CCW-rotated tate CRT (Pi), boots CW, and the OSD Flip Screen produces a clean, persistent right-side-up 180°. Rotation `vertical (cw)` is correct (MAME/arcadeitalia `popflamn` = ROT90 = cw) and left unchanged; flip=yes adds the `screentateccw`/`screentateflip` tags so it downloads on CCW-tate setups instead of being excluded as `screentatecwnoflip`. The distributed MRA also declares `<flip>yes</flip>`.

**2. name (`Pop Flamer [bl]` → `Pop Flamer (Bootleg conversion)`).** The distributed MRA (Arcade-NaughtyBoy_MiSTer `releases/`) is `Pop Flamer (Bootleg conversion).mra`. Since the generated entry's `file` = `<name>.mra`, the old name generated `Pop Flamer [bl].mra` and never joined the real MRA. Corrected to the exact distributed filename. setname (`popflamn`) is unchanged, so download tag-matching is unaffected.

Diff is a single row (1 insertion / 1 deletion), CSV only.