### PR TITLE
Port Man (porter): set flip=yes + fix name/year/inputs

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2214,7 +2214,7 @@ tmntu,"Teenage Mutant Ninja Turtles (US, 4P, Ver. R)",USA,"4 Player, Version R",
 mia,M.I.A. - Missing in Action (Ver. T),World,Version T,no,M.I.A. - Missing in Action,Konami TMNT based,Green Beret,no,no,1989,Konami,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 mia2,M.I.A. - Missing in Action (Ver. S),World,Version S,yes,M.I.A. - Missing in Action,Konami TMNT based,Green Beret,no,no,1989,Konami,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 moonqsr,Moon Quasar,World,,no,Moon Quasar,Namco Galaxian based,Moon Quasar,no,no,1980,Nichibutsu,Shooter - Gallery,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,1
-porter,Port Man (Moon Cresta hardware) [bl],World,Moon Cresta hardware,no,Port Man,Namco Galaxian based,Port Man,no,no,1980,bootleg,Platform - Run Jump,,15kHz,vertical (cw),,,2 (alternating),8-way,,1
+porter,Port Man (bootleg on Moon Cresta hardware),World,Moon Cresta hardware,no,Port Man,Namco Galaxian based,Port Man,no,no,1982,bootleg,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 aliens,"Aliens (W, Set 1)",World,Set 1,no,Aliens,Konami Aliens based,Alien,no,no,1990,Konami,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 aliens2,"Aliens (W, Set 2)",World,Set 2,yes,Aliens,Konami Aliens based,Alien,no,no,1990,Konami,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 aliens3,"Aliens (W, Set 3)",World,Set 3,yes,Aliens,Konami Aliens based,Alien,no,no,1990,Konami,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2


### PR DESCRIPTION
Single-row correctness fix for **Port Man** (`porter`, galaxian core — bootleg of Dock Man on Moon Cresta hardware). Diagnosed from a missing details/download on a CCW-tate setup.

**Changes (one row):**

- **flip: blank → yes.** Hardware-verified on a CCW tate CRT: Port Man boots CW and the galaxian core's OSD **Flip Screen** toggle gives a clean, persistent right-side-up 180°. This is the same ROM-agnostic core flip already marked `yes` on its galaxian siblings (Moon Quasar, Moon Alien, Galaxian Part X). Adds `screentateccw`/`screentateflip` so the game reaches CCW-tate systems (currently excluded as `screentatecwnoflip`). The MRA already declares `<flip>yes</flip>`.
- **name: `Port Man (Moon Cresta hardware) [bl]` → `Port Man (bootleg on Moon Cresta hardware)`** to exactly match the distributed MRA filename (`Port Man (bootleg on Moon Cresta hardware).mra` in Distribution_MiSTer / Arcade-Galaxian releases). The old name generated a `file` that didn't join to the MRA.
- **year: 1980 → 1982** per MAME / adb.arcadeitalia (`porter`). 1980 is the Moon Cresta base-hardware year; Port Man / its parent Dock Man are 1982.
- **move_inputs: 8-way → 2-way horizontal** per the MRA (`<joystick>2-way horizontal</joystick>`) and the galaxian-core siblings (moonqsr/moonaln/galapx), matching the actual Moon Cresta hardware controls.

Rotation left unchanged (`vertical (cw)` = MAME ROT90, correct). Diff is CSV-only, 1 insertion / 1 deletion.