### PR TITLE
Rumba Lumber (rumba): set flip=yes

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2565,7 +2565,7 @@ nycaptor,N.Y. Captor (Rev 2),World,Rev 2,no,,Taito N.Y. Captor hardware,,no,no,1
 colt,Colt [bl],bootleg,bootleg,yes,N.Y. Captor,Taito N.Y. Captor hardware,,no,yes,1985,Taito,Shooter - Gun,,15kHz,horizontal,,,1,,Lightgun,1
 onna34ro,Onna Sanshirou - Typhoon Gal (Rev 1),World,Rev 1,no,,Taito The FairyLand Story hardware,,no,no,1985,Taito,Fighter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,2
 onna34roa,Onna Sanshirou - Typhoon Gal [bl],bootleg,bootleg,yes,Onna Sanshirou - Typhoon Gal,Taito The FairyLand Story hardware,,no,yes,1985,Taito,Fighter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,2
-rumba,Rumba Lumber (Rev 1),World,Rev 1,no,,Taito The FairyLand Story hardware,,no,no,1984,Taito,Maze - Collect,,15kHz,vertical (ccw),,,2 (alternating),8-way,,2
+rumba,Rumba Lumber (Rev 1),World,Rev 1,no,,Taito The FairyLand Story hardware,,no,no,1984,Taito,Maze - Collect,,15kHz,vertical (ccw),yes,,2 (alternating),8-way,,2
 victnine,Victorious Nine,World,,no,,Taito The FairyLand Story hardware,,no,no,1984,Taito,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
 bronx,Bronx [bl],bootleg,,yes,Cycle Shooting,Taito N.Y. Captor hardware,,no,no,1986,bootleg,Shooter - Gun,,15kHz,vertical (cw),,,1,,Lightgun,1
 juju,JuJu Densetsu (JP),Japan,,no,Toki,Seibu Toki hardware,,no,no,1989,TAD Corporation,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2


### PR DESCRIPTION
`rumba` (Rumba Lumber, Rev 1) on jotego's **`jtflstory`** core (Taito FairyLand Story hardware) is `vertical (ccw)` — MAME/adb.arcadeitalia `rumba`=ROT270, matches the row + jtbin MRA — with a blank flip field.

Its MRA exposes a hardware **Flip Screen DIP** (`<dip name="Flip" ids="Off,On" bits="24"/>`); hardware-tested on a CCW tate CRT, the OSD flip works and gives a persistent right-side-up 180°. Setting `flip=yes` so the entry also carries `screentateflip` (metadata accuracy + CW-tate setups). Being ccw-native it already reaches CCW-tate systems regardless.

Public core (no `jtbeta.zip` in the MRA). Rotation unchanged; flip-field only, 1 row.