### PR TITLE
Add Sky Smasher (skysmash) - missing MAD entry

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -1687,6 +1687,7 @@ skyrobo,Sky Robo,World,,yes,Tatakae! Big Fighter,Nichibutsu M68000 (Armed F),,no
 skyshark,"Sky Shark (US, Set 1)",USA,Set 1,yes,Flying Shark,Toaplan Twin Cobra hardware,,no,no,1987,Toaplan - Taito America Corporation (Romstar license),Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 skysharka,"Sky Shark (US, Set 2)",USA,Set 2,yes,Flying Shark,Toaplan Twin Cobra hardware,,no,no,1987,Toaplan - Taito America Corporation (Romstar license),Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 skyskipr,Sky Skipper,World,,no,,Nintendo Arcade,,no,no,1981,Nintendo,Shooter - Flying,,15kHz,horizontal,,,2 (alternating),8-way,,2
+skysmash,Sky Smasher,World,,no,Sky Smasher,SNK - Alpha Denshi,,no,no,1990,Nihon System,Shooter - Flying Vertical,,15kHz,vertical (ccw),no,,2 (simultaneous),8-way,,2
 skysoldr,Sky Soldiers (US),USA,,no,Sky Soldiers,SNK - Alpha Denshi,Sky Soldiers,no,no,1988,Alpha Denshi Co.,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
 slammast,"Saturday Night Slam Masters (W, 930713)",World,930713,no,,Capcom CPS-1.5,Slam Masters,no,no,1993,Capcom,Sports - Wrestling,,15kHz,horizontal,n-a,,4 (simultaneous),8-way,,3
 slammastu,"Saturday Night Slam Masters (US, 930713)",USA,930713,yes,Slam Masters,Capcom CPS-1.5,Slam Masters,no,no,1993,Capcom,Sports - Wrestling,,15kHz,horizontal,n-a,,4 (simultaneous),8-way,,3


### PR DESCRIPTION
`skysmash` (Sky Smasher, Nihon System 1990, Alpha Denshi hardware) has no MAD row (`nomadentrymra`), so it gets no screen tags and never downloads. It runs on the dedicated **`SkySmasher`** core (`SkySmasher_20260608.rbf`, MiSTer-devel Distribution).

New row: `vertical (ccw)` — MAME/adb.arcadeitalia `skysmash`=ROT270=ccw, and hardware-verified boots ccw right-side-up on a CCW tate CRT (note the distributed MRA's `<rotation>vertical (cw)</rotation>` is a mislabel — MAME + the core's actual display agree ccw). `flip=no` (the core's 'Flip 180' option is non-functional on CRT, hardware-tested). Being ccw-native it downloads and displays correctly regardless.

Fields from the MRA + MAME/arcadeitalia, mirroring the sibling `skysoldr`/`skyadvnt` Alpha Denshi rows: platform `SNK - Alpha Denshi`, `Shooter - Flying Vertical`, 2 (simultaneous), 8-way, 2 buttons (Shoot/Missile). 1 row added.