### PR TITLE
TwinBee (twinbee, twinbeeb): set flip=yes

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -2546,8 +2546,8 @@ ryukendna,"Ninja Ryukenden (JP, Set 2)",Japan,Set 2,no,Shadow Warriors,Tecmo Nin
 shadowwa,"Shadow Warriors (W, Set 2)",World,Set 2,yes,Shadow Warriors,Tecmo Ninja Gaiden hardware,,no,no,1988,Tecmo,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 gradius,"Gradius (JP, ROM Version)",Japan,Rom Version,no,Nemesis,Konami GX400,Gradius,no,no,1985,Konami,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
 gwarrior,Galactic Warriors,World,,no,,Konami GX400,,no,no,1985,Konami,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
-twinbee,TwinBee (ROM Version),World,Rom Version,no,,Konami GX400,Twin Bee,no,no,1985,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-twinbeeb,TwinBee (Bubble System),World,Bubble System,no,Bubble System Bios,Konami GX400,Twin Bee,no,no,1985,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
+twinbee,TwinBee (ROM Version),World,Rom Version,no,,Konami GX400,Twin Bee,no,no,1985,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
+twinbeeb,TwinBee (Bubble System),World,Bubble System,no,Bubble System Bios,Konami GX400,Twin Bee,no,no,1985,Konami,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 avengers,"Avengers (US, Rev C)",USA,Rev C,no,,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 avengersb,Avengers (US),USA,,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 avengersa,"Avengers (US, Rev A)",USA,Rev A,yes,Avengers,Capcom CPS-0,,no,no,1987,Capcom,Fighter - Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2


### PR DESCRIPTION
`twinbee` (TwinBee ROM version, **BubSysROM** core) and `twinbeeb` (TwinBee Bubble System, **BubSys** core) — Konami GX400, 1985 — are `vertical (cw)` (MAME/adb.arcadeitalia `twinbee`/`bs_twinbee`=ROT90=cw) with a blank flip field, so both are excluded from CCW-tate setups.

Both expose a working screen-flip DIP; hardware-tested on a CCW tate CRT — each gives a persistent right-side-up 180°. Tested on **both cores separately** (the ROM version and the Bubble System version run on different cores). Setting `flip=yes` → each gains `screentateccw`/`screentateflip` (download-enabler).

Rotation unchanged. Flip-field only, 2 rows.