### PR TITLE
Add Vastar (vastar) - missing MAD entry

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -1933,6 +1933,7 @@ varthj,"Varth- Operation Thunderstorm (JP, 920714)",Japan,920714,yes,Varth,Capco
 varthjr,"Varth- Operation Thunderstorm (JP, Resale)",Japan,920714 Resale,yes,Varth,Capcom CPS-1,,no,no,1992,Capcom,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,3
 varthr1,"Varth- Operation Thunderstorm (W, 920612)",World,920612,yes,Varth,Capcom CPS-1,,no,no,1992,Capcom,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,3
 varthu,"Varth- Operation Thunderstorm (US, 920612)",USA,920612,yes,Varth,Capcom CPS-1,,no,no,1992,Capcom,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,3
+vastar,Vastar,World,,no,Vastar,Vastar hardware,,no,no,1983,Orca,Shooter - Flying Vertical,,15kHz,vertical (cw),no,,2 (alternating),4-way,,2
 vautour,"Vautour (Phoenix, 8085A CPU) [bl]",World,"Phoenix, 8085A CPU",yes,Phoenix,Taito Unique,,no,yes,1980,Tehkan,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,2
 vautourza,"Vautour (Phoenix, Z80 CPU, Single PROM) [bl]",World,"Phoenix, Z80 CPU, Single PROM",yes,Phoenix,Taito Unique,,no,yes,1980,Tehkan,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,2
 vball,U.S. Championship V'ball (US),USA,,no,,Taito Licensed,,no,no,1988,Technos,Sports - Volleyball,,15kHz,horizontal,,,4 (simultaneous),8-way,,2


### PR DESCRIPTION
`vastar` (Vastar, Orca 1983) has no MAD row (`nomadentrymra`). Runs on the MiSTer-devel **`Vastar`** core (`Vastar_20260531.rbf`), same core as Planet Probe (added earlier).

New row: `vertical (cw)` — MAME/adb.arcadeitalia `vastar`=ROT90=cw, and hardware boots CW/upside-down on a CCW tube (the MRA is correctly labeled cw here). `flip=no` — the Vastar core has no working flip (OSD toggle non-functional, hardware-tested, consistent with Planet Probe). So it's CW-native with no flip and won't auto-download to CCW-tate systems — this is a catalog-completeness entry (like the Planet Probe add).

Fields from the MRA + MAME/arcadeitalia: platform `Vastar hardware`, manufacturer `Orca`, 1983, 2 (alternating), 4-way. Category `Shooter - Flying Vertical` and 2 buttons are best-guesses (MRA lacks a buttons tag) — please adjust if needed. 1 row added.