### PR TITLE
Add Gulf War II and Space Firebird / Space Demon (4 rows, hardware-tested)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -801,6 +801,8 @@ gteikoku,Gingateikoku no Gyakushu,Japan,,yes,UniWar S,Irem Unique,,no,no,1980,Ir
 gteikokub,Gingateikoku no Gyakushu (Set 1) [bl],Japan,Set 1,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,1
 gteikokub2,Gingateikoku no Gyakushu (Set 2) [bl],Japan,Set 2,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 gteikokub3,Gingateikoku no Gyakushu (Set 3) [bl],Japan,Set 3,yes,UniWar S,Irem Unique,,no,yes,1980,Honly,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
+gulfwar2,Gulf War II (set 1),World,set 1,no,Gulf War II,Toaplan Twin Cobra hardware,,no,no,1991,Comad,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+gulfwar2a,Gulf War II (set 2),World,set 2,yes,Gulf War II,Toaplan Twin Cobra hardware,,no,no,1991,Comad,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 gulunpa,"Gulun.Pa (931220 L, Prototype)",World,"931220 L, Prototype",no,,Capcom CPS-1,,no,no,1990,Capcom,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
 gunfight,Gun Fight,World,,no,,Midway 8080,,no,no,1975,Dave Nutting Associates - Midway,Shooter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,0
 gunforc2,Gun Force II (US),USA,,no,Gun Force II,Irem M92,Gun Force,no,no,1994,Irem,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -1711,6 +1713,8 @@ sonsonj,SonSon (JP),Japan,,yes,SonSon,Capcom CPS-0,SonSon,no,no,1984,Capcom,Plat
 sosterm,S.O.S.,World,,no,,TIAMC1,,no,no,1988,Terminal,"Platform - Run, Jump &amp; Scrolling",,15kHz,horizontal,,,1,4-way,,1
 spacbat2,Space Battle (Set 2) [bl],World,Set 2,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 spacbatt,Space Battle (Set 1) [bl],World,Set 1,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
+SpaceDemon,Space Demon,World,,no,Space Firebird,Nintendo Arcade,,no,no,1980,Nintendo (Fortrek license),Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,2
+spacefb,Space Firebird,World,,no,Space Firebird,Nintendo Arcade,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,2
 spacempr,Space Empire [bl],World,,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 spaceplt,Space Pilot (Time Pilot bootleg) [bl],World,,yes,,Konami Z80,,no,yes,1982,,Shooter - Field,,15kHz,vertical (cw),no,,2 (alternating),8-way,,1
 spacerace,Space Race,World,,no,,Atari Discrete hardware,,no,no,1973,Atari,Racing,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,,0


### PR DESCRIPTION
Adds MAD entries for three vertical games (plus one alternative) that currently have no rows (`nomadentrymra`, no screen tags), so tate-filtered downloader setups skip them even though their RBFs and ROMs download.

**New rows (4):**
- `gulfwar2` + `gulfwar2a` — Gulf War II (GulfWarII core). Comad 1991; MAME places it on Toaplan Twin Cobra-derived hardware (toaplan/twincobr.cpp), so the platform reuses the existing `Toaplan Twin Cobra hardware` string.
- `spacefb` — Space Firebird (SpaceFirebird core), Nintendo 1980; platform `Nintendo Arcade` per the existing popeye/skyskipr rows.
- `SpaceDemon` — Space Demon (Fortrek-licensed Space Firebird), same core. **Note:** the distributed MRA's `<setname>` is literally `SpaceDemon` (not MAME's `spacedem`), so the row uses that exact string to match — first non-lowercase setname in the CSV; happy to adjust if you'd rather the core repo fix its MRA instead.

**Hardware-tested on a CCW-rotated tate CRT (MiSTer Pi):** all three boot counter-clockwise right-side-up, matching MAME (ROT270 = ccw on every set, verified via arcadeitalia), and each has a working screen-flip option in the core OSD → `vertical (ccw)` + `flip=yes`. Rotation and flip both observed, not inferred.

Other fields per MAME and the distributed MRAs: Gulf War II 2 (simultaneous)/8-way/2 buttons (Shot, Bomb per the MRA); Space Firebird games 2 (alternating)/2-way horizontal/2 buttons; categories from MAME catver (`Shooter - Flying Vertical`, `Shooter - Gallery`).