### PR TITLE
Correct rotation to match MAME on 30 rows (consolidates 5 PRs)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -208,7 +208,7 @@ bgareggatw,Battle Garegga (TW- DE),Taiwan,(TW- DE) (Thu Feb 1 1996),yes,Battle G
 bgareggz,Battle Garegga (Zakk roms) (EU- US - JP - AS) [hb],World,(Zakk roms) (EU- US - JP - AS) (Sat Feb 3 1996),yes,Battle Garegga,Toaplan 2,,no,no,1996,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
 bgareggak,Battle Garegga (KO - GR),World,(KO-GR),yes,Battle Garegga,Toaplan 2,,no,no,1996,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
 bigfghtr,Tatakae! Big Fighter,World,,no,Tatakae! Big Fighter,Nichibutsu M68000 (Armed F),,no,no,1989,Nichibutsu,Shooter - Walking,,15kHz,horizontal,,,2 (alternating),8-way,,2
-bigkong,Big Kong,World,,no,Big Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+bigkong,Big Kong,World,,no,Big Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
 bilyard,Billiard,World,,no,Billiard,TIAMC1,,no,no,1988,Terminal,Sports - Pool,,15kHz,horizontal,,,1,2-way horizontal,,1
 bionicc,Bionic Commando,World,,no,Bionic Commando,Capcom CPS-0,,no,no,1987,Capcom,Platform - Shooter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 bionicc1,"Bionic Commando (US, Set 1)",USA,Set 1,yes,Bionic Commando,Capcom CPS-0,,no,no,1987,Capcom,Platform - Shooter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
@@ -344,19 +344,19 @@ chtpman2,New Puck 2 (Cheat) [hb],World,Cheat,yes,Pac-Man,Namco Pac-Man hardware,
 chtpop,"Pac-Man (Popeye, Cheat) [hb]",World,"Popeye, Cheat",yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Namco - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 chtpuck,New Puck X (Cheat) [hb],World,Cheat,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Deluxe,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 chwy,Highway Chase,USA,,no,Highway Chase,Data East DECO Cassette,,no,no,1980,Data East,Shooter - Driving Vertical,,15kHz,vertical (ccw),,,2 (alternating),,,2
-ckong,Crazy Kong (Kyoei),World,Kyoei,no,,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon - Kyoei,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+ckong,Crazy Kong (Kyoei),World,Kyoei,no,,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon - Kyoei,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
 ckong3a,Crazy Kong Part II (Set 2) [hb],World,Set 2,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 ckonga2,Crazy Kong Part II (Set 1) [hb],World,Set 1,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 ckonga3,Crazy Kong Part II - 2 [hb],World,,no,,Donkey Kong hardware,Donkey Kong,yes,no,1981,,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongdks,"Donkey Kong (ES, Crazy Kong) [bl]",Spain,"Spanish, Crazy Kong",yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+ckongdks,"Donkey Kong (ES, Crazy Kong) [bl]",Spain,"Spanish, Crazy Kong",yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
 ckongfix,Crazy Kong Part II (GFX Fix) [hb],World,GFX Fix,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongo,Crazy Kong (Orca Bootleg) [bl],World,Orca Bootleg,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongpt2,Crazy Kong Part II (Set 1),World,Set 1,no,,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongpt2a,Crazy Kong Part II (Set 2),World,Set 2,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongpt2b2,Crazy Kong Part II [bl],World,,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongpt2b,Crazy Kong Part II (Alternative Levels) [bl],World,Alternative Levels,no,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongpt2j,Crazy Kong Part II (JP),Japan,,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-ckongpt2jeu,Crazy Kong Part II (Jeutal) [bl],World,Jeutal,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon - Jeutel,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+ckongo,Crazy Kong (Orca Bootleg) [bl],World,Orca Bootleg,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
+ckongpt2,Crazy Kong Part II (Set 1),World,Set 1,no,,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
+ckongpt2a,Crazy Kong Part II (Set 2),World,Set 2,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
+ckongpt2b2,Crazy Kong Part II [bl],World,,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
+ckongpt2b,Crazy Kong Part II (Alternative Levels) [bl],World,Alternative Levels,no,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
+ckongpt2j,Crazy Kong Part II (JP),Japan,,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Falcon,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
+ckongpt2jeu,Crazy Kong Part II (Jeutal) [bl],World,Jeutal,yes,Crazy Kong,Donkey Kong hardware,Donkey Kong,no,yes,1981,Falcon - Jeutel,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,1
 clapapa2,Rootin Tootin,USA,,no,Rootin Tootin,Data East DECO Cassette,,no,no,1983,Data East,Maze - Collect,,15kHz,vertical (ccw),,,2 (alternating),4-way,,2
 cleansweept,Clean Sweep,World,TTL,no,Galaxian,Namco Galaxian based,,yes,no,1982,Marco and Ivan,Maze - Collect,,15kHz,vertical (cw),yes,,1,,rotary,0
 clocknch,Lock'n'Chase,USA,,no,Lock'n'Chase,Data East DECO Cassette,,no,no,1981,Data East,Maze - Collect,,15kHz,vertical (ccw),,,2 (alternating),4-way,,2
@@ -521,20 +521,20 @@ dizzy,Dizzy Ghost- A Reversal of Roles [hb],World,,yes,Pac-Man,Namco Pac-Man har
 dkfreerun,Donkey Kong Freerun Edition (Freerun) [hb],World,Freerun,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dkgensan,"Daiku no Gensan (JP, M84 hardware)",Japan,,yes,Daiku no Gensan,Irem M72,,no,no,1990,Irem,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 dkgensanm72,"Daiku no Gensan (JP, M72 hardware)",Japan,,no,Daiku no Gensan,Irem M72,,no,no,1990,Irem,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
-dkong,"Donkey Kong (US, Set 1)",USA,Set 1,no,,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
+dkong,"Donkey Kong (US, Set 1)",USA,Set 1,no,,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
 dkong2m,Donkey Kong (2 Marios) [hb],World,2 Marios,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-dkong3,Donkey Kong 3 (US),USA,,no,,Donkey Kong hardware,Donkey Kong,no,no,1983,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
-dkong3b,Donkey Kong 3 [bl],World,,yes,Donkey Kong 3,Donkey Kong hardware,Donkey Kong,no,yes,1984,,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+dkong3,Donkey Kong 3 (US),USA,,no,,Donkey Kong hardware,Donkey Kong,no,no,1983,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkong3b,Donkey Kong 3 [bl],World,,yes,Donkey Kong 3,Donkey Kong hardware,Donkey Kong,no,yes,1984,,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
 dkongbcc,Donkey Kong (Barrel Control Coloring) [hb],World,Barrel Control Coloring,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dkongex,Donkey Kong Foundry (Foundry) [hb],World,Foundry,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dkongf,"Donkey Kong Foundry (Foundry, Hack) [hb]",World,"Foundry, Hack",yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-dkonghrd,Donkey Kong (Hard),World,Hard,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-dkongj,"Donkey Kong (JP, Set 1)",Japan,Set 1,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-dkongjo,"Donkey Kong (JP, Set 2)",Japan,Set 2,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-dkongjo1,"Donkey Kong (JP, Set 3)",Japan,Set 3,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-dkongjr,"Donkey Kong Junior (US, Set F-2)",USA,Set F-2,no,Donkey Kong Junior,Donkey Kong hardware,Donkey Kong,no,no,1982,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
-dkongjrj,Donkey Kong Jr. (JP),Japan,,yes,Donkey Kong Junior,Donkey Kong hardware,Donkey Kong,no,no,1982,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
-dkongo,"Donkey Kong (US, Set 2)",USA,Set 2,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+dkonghrd,Donkey Kong (Hard),World,Hard,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkongj,"Donkey Kong (JP, Set 1)",Japan,Set 1,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkongjo,"Donkey Kong (JP, Set 2)",Japan,Set 2,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkongjo1,"Donkey Kong (JP, Set 3)",Japan,Set 3,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkongjr,"Donkey Kong Junior (US, Set F-2)",USA,Set F-2,no,Donkey Kong Junior,Donkey Kong hardware,Donkey Kong,no,no,1982,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkongjrj,Donkey Kong Jr. (JP),Japan,,yes,Donkey Kong Junior,Donkey Kong hardware,Donkey Kong,no,no,1982,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
+dkongo,"Donkey Kong (US, Set 2)",USA,Set 2,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,no,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
 dkongp,Donkey Kong (Patched) [hb],World,Patched,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dkongpac,Donkey Kong (Pac-Man GFX) [hb],World,Pac-Man GFX,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dkongpe,"Donkey Kong (Pauline, Rev 5) [hb]",World,"Pauline, Rev 5",yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
@@ -1383,8 +1383,8 @@ quartet,"Quatret (W, 4 Players) Rev A",World,"Rev A, 4 Players",no,Quatret,Sega 
 quartet2,Quatret 2 (W),World,8751 317-0010,yes,Quatret,Sega System 16,Quatret,no,no,1986,Sega,Maze - Shooter Large,,15kHz,horizontal,no,,4 (simultaneous),8-way,,2
 quartet2a,"Quatret 2 (W, No Protection)",World,No Protection,no,Quatret,Sega System 16,Quatret,no,no,1986,Sega,Maze - Shooter Large,,15kHz,horizontal,no,,4 (simultaneous),8-way,,2
 quarteta,"Quatret (W, 4 Players)",World,"4 Players, 8751 315-5194",yes,Quatret,Sega System 16,Quatret,no,no,1986,Sega,Maze - Shooter Large,,15kHz,horizontal,no,,4 (simultaneous),8-way,,2
-radarscp,Radar Scope,World,,no,,Donkey Kong hardware,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,1
-radarscpc,Radar Scope (Rev C),World,,yes,,Donkey Kong hardware,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,1
+radarscp,Radar Scope,World,,no,,Donkey Kong hardware,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (ccw),no,,2 (alternating),2-way horizontal,,1
+radarscpc,Radar Scope (Rev C),World,,yes,,Donkey Kong hardware,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (ccw),no,,2 (alternating),2-way horizontal,,1
 raflesia,Rafflesia (315-5162),Japan,315-5162,no,,Sega System 1,,no,no,1986,Sega,Shooter - Flying Vertical,,15kHz,vertical (ccw),no,,2 (alternating),8-way,,2
 ragtime,"The Great Ragtime Show (Japan v1.5, 92.12.07)",Japan,"v1.5, 92.12.07",yes,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 ragtimea,"The Great Ragtime Show (Japan v1.3, 92.11.26)",Japan,"v1.3, 92.11.26",yes,Boogie Wings,Data East DE-0379 hardware,,no,no,1992,Data East Corporation,Shooter - Misc. Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -1437,8 +1437,8 @@ robotrontie,Robotron 2084 (Tie-Die) [hb],World,Tie-Die,yes,Robotron 2084,William
 robotronyo,Robotron 2084 (Yellow-Orange Label),World,Yellow-Orange Label,yes,Robotron 2084,Williams 1st Generation,,no,no,1982,Williams - Vid Kidz,Shooter - Field,,15kHz,horizontal,,,1,8-way,twin stick,4
 rockman2j,"Rockman 2- The Power Fighters (JP, 960708)",Japan,960708,yes,Mega Man 2- The Power Fighters,Capcom CPS-2,Mega Man,no,no,1996,Capcom,Fighter - Versus Co-op,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,3
 rockmanj,"Rockman- The Power Battle (JP, 950922)",Japan,950922,yes,Mega Man- The Power Battle,Capcom CPS-1,Mega Man,no,no,1995,Capcom,Fighter - Versus Co-op,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
-rocnrope,Roc'n Rope,World,,no,Roc'n Rope,Konami 6809 based,,no,no,1983,Konami,Platform - Run Jump,,15kHz,vertical (cw),,,2 (alternating),4-way,,2
-rocnropek,Roc'n Rope (Kosuka),World,,yes,Roc'n Rope,Konami 6809 based,,no,no,1983,Konami,Platform - Run Jump,,15kHz,vertical (cw),,,2 (alternating),4-way,,2
+rocnrope,Roc'n Rope,World,,no,Roc'n Rope,Konami 6809 based,,no,no,1983,Konami,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,2
+rocnropek,Roc'n Rope (Kosuka),World,,yes,Roc'n Rope,Konami 6809 based,,no,no,1983,Konami,Platform - Run Jump,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,2
 rpatroln,"River Patrol (JP, Unprotected)",Japan,Unprotected,no,,Taito Licensed,,no,no,1981,Orca,Driving - Boat,,15kHz,horizontal,,,2 (alternating),2-way horizontal,,1
 rtype,R-Type (W),World,,no,R-Type,Irem M72,R-Type,no,no,1987,IREM,Shooter - Flying Horizontal,,15kHz,horizontal,,,1,8-way,,2
 rtype2,R-Type II (W),World,,no,R-Type II,Irem M72,R-Type,no,no,1989,Irem,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,2
@@ -1742,9 +1742,9 @@ sprint2a,Sprint 2 (Set 2),World,Set 2,yes,Sprint 2,Atari 6502,Sprint,no,no,1976,
 spyhunt,Spy Hunter,World,,no,,Midway MCR3,,no,no,1983,Bally,Shooter - Driving Vertical,,15kHz,vertical (cw),no,,1,,paddle - pedal,1
 spyhuntp,Spy Hunter (Playtronic),World,Playtronic,yes,Spy Hunter,Midway MCR3,,no,no,1983,Bally - Midway - Playtronic,Shooter - Driving Vertical,,15kHz,vertical (cw),no,,1,8-way,,5
 squaitsa,Squash (Itisa),World,Itisa,no,,Taito Licensed,,no,no,1984,Itisa,Sports - Tennis,,15kHz,horizontal,,,2 (simultaneous),4-way,,1
-srumbler,The Speed Rumbler (Set 1),World,Set 1,no,The Speed Rumber,Capcom CPS-0,,no,no,1986,Capcom,Shooter - Driving Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-srumbler2,The Speed Rumbler (Set 2),World,Set 2,yes,The Speed Rumber,Capcom CPS-0,,no,no,1986,Capcom,Shooter - Driving Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
-srumbler3,The Speed Rumbler (Set 3),World,Set 3,yes,The Speed Rumber,Capcom CPS-0,,no,no,1986,Capcom,Shooter - Driving Vertical,,15kHz,vertical (cw),,,2 (simultaneous),8-way,,2
+srumbler,The Speed Rumbler (Set 1),World,Set 1,no,The Speed Rumber,Capcom CPS-0,,no,no,1986,Capcom,Shooter - Driving Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+srumbler2,The Speed Rumbler (Set 2),World,Set 2,yes,The Speed Rumber,Capcom CPS-0,,no,no,1986,Capcom,Shooter - Driving Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+srumbler3,The Speed Rumbler (Set 3),World,Set 3,yes,The Speed Rumber,Capcom CPS-0,,no,no,1986,Capcom,Shooter - Driving Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 ssf2,"Super Street Fighter II- The New Challengers (W, 931005)",World,931005,no,,Capcom CPS-2,Street Fighter,no,no,1993,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
 ssf2a,"Super Street Fighter II- The New Challengers (AS, 931005)",Asia,931005,yes,Super Street Fighter II- The New Challengers,Capcom CPS-2,Street Fighter,no,no,1993,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
 ssf2ar1,"Super Street Fighter II- The New Challengers (AS, 930914)",Asia,930914,yes,Super Street Fighter II- The New Challengers,Capcom CPS-2,Street Fighter,no,no,1993,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
@@ -2038,9 +2038,9 @@ wofch,"Tenchi wo Kurau II- Sekiheki no Tatakai (JP, CPS Changer, 921031)",Japan,
 wonder3,"Wonder 3 (JP, 910520)",Japan,910520,yes,Three Wonders,Capcom CPS-1,,no,no,1991,Capcom,MultiGame - Compilation,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
 woodpeck,Woodpecker (Set 1),World,Set 1,no,,Namco Pac-Man hardware,,no,no,1981,Amenip - Palcom Queen River,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
 wow,Wizard of Wor,World,,no,,Midway Astrocade,,no,no,1980,Dave Nutting Associates - Midway,Maze - Shooter Small,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
-wrestwar,"Wrestle War (W, Set 3)",World,Set 3,no,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
-wrestwar1,"Wrestle War (JP, Set 1)",Japan,Set 1,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
-wrestwar2,"Wrestle War (W, Set 2)",World,Set 2,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
+wrestwar,"Wrestle War (W, Set 3)",World,Set 3,no,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,vertical (ccw),n-a,,2 (simultaneous),8-way,,2
+wrestwar1,"Wrestle War (JP, Set 1)",Japan,Set 1,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,vertical (ccw),n-a,,2 (simultaneous),8-way,,2
+wrestwar2,"Wrestle War (W, Set 2)",World,Set 2,yes,Wrestle War,Sega System 16,,no,no,1989,Sega,Sports - Wrestling,,15kHz,vertical (ccw),n-a,,2 (simultaneous),8-way,,2
 xensad,Xens Revenge After Dark [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,,yes,no,1980,Jeff Morris,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 xensrev,Xens Revenge [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,,yes,no,1980,Jeff Morris,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 xeviblk,Xevious Black [hb],World,,yes,Xevious,Namco Galaga based,,yes,no,1982,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),no,,2 (alternating),8-way,,2


### PR DESCRIPTION
Consolidation of the open rotation PRs into one, as requested: #79, #89, #90, #91, #100. Diffs combined unchanged (verified byte-identical union, rebuilt on current main); the originals will be closed with a pointer here.

One rule applied throughout, per your guidance: rotation follows MAME / adb.arcadeitalia (original cabinet orientation), not core boot behavior. Every set below was checked against MAME and arcadeitalia; details and hardware notes are in the original PRs.

30 rows:

| Sets | Change | Flip | Original PR |
|---|---|---|---|
| wrestwar, wrestwar1, wrestwar2 (jts16b) | horizontal to vertical (ccw), MAME ROT270 | unchanged (no flip on the core) | #79 |
| radarscp, radarscpc (DonkeyKong core) | cw to ccw, MAME ROT270 | set to no (core flip broken for Radar Scope; the MRA itself declares flip broken; hardware-tested) | #89 |
| rocnrope, rocnropek (jtroc) | cw to ccw, MAME ROT270 | set to no (no flip, hardware-tested) | #90 |
| 20 Donkey Kong hardware sets: dkong x6, dkongjr x2, dkong3 x2, Crazy Kong family x10 | cw to ccw; the whole dkong.cpp / Crazy Kong family is MAME ROT270 | no to yes on 6 true clones of dkong/dkong3 (they ride the parents' working flip); Crazy Kong stays no | #91 |
| srumbler, srumbler2, srumbler3 (jtrumble) | cw to ccw, MAME ROT270 | blank to yes (working core flip, hardware-tested) | #100 |

Note: the identical rotation fix for shienryu (from #80) rides in the ST-V name-fields PR instead, because it lands on the same CSV row as that PR's name fix.

Note: if this conflicts after one of the other consolidated PRs merges, I will rebase it promptly.
