### PR TITLE
Eyes: fix manufacturer typo (Tehstar -> Techstar), eyeszac licensee, and alternative names

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -610,8 +610,8 @@ extrmatnj,Extermination (JP),Japan,,yes,Extermination,Taito The NewZealand Story
 extrmatnu,"Extermination (US, World Games)",USA,World Games,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito (World Games license),Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 extrmatnur,"Extermination (US, Romstar)",USA,Romstar,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito America Corporation (Romstar license),Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 eyes,"Eyes (US, Set 1)",USA,Set 1,no,,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
-eyes2,Eyes (US set 2),USA,Set 2,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-eyeszac,Eyes (Italy),Italy,,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Zaccaria,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+eyes2,Eyes (US Set 2),USA,Set 2,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+eyeszac,Eyes (IT),Italy,,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Zaccaria,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 f1dream,F-1 Dream,World,,no,F-1 Dream,Capcom CPS-0,,no,no,1988,Capcom,Driving - Race,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 falcon,Falcon (8085A CPU) [bl],World,8085A CPU,yes,Phoenix,Taito Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 fantzn2,Fantasy Zone II - The Tears of Opa-Opa (SSE),Japan,"MC8123, 317-0057",no,,Sega System E,,no,no,1988,Sega,Shooter - Flying Horizontal,,15kHz,horizontal,,,1,8-way,,2

--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -609,9 +609,9 @@ extrmatn,Extermination (W),World,,no,Extermination,Taito The NewZealand Story ha
 extrmatnj,Extermination (JP),Japan,,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito Corporation Japan,Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 extrmatnu,"Extermination (US, World Games)",USA,World Games,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito (World Games license),Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 extrmatnur,"Extermination (US, Romstar)",USA,Romstar,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito America Corporation (Romstar license),Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
-eyes,"Eyes (US, Set 1)",USA,Set 1,no,,Namco Pac-Man hardware,,no,no,1982,Tehstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
-eyes2,"Eyes (US, Set 2)",USA,Set 2,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Tehstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
-eyeszac,Eyes (IT),Italy,,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Tehstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+eyes,"Eyes (US, Set 1)",USA,Set 1,no,,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
+eyes2,Eyes (US set 2),USA,Set 2,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+eyeszac,Eyes (Italy),Italy,,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Zaccaria,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 f1dream,F-1 Dream,World,,no,F-1 Dream,Capcom CPS-0,,no,no,1988,Capcom,Driving - Race,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 falcon,Falcon (8085A CPU) [bl],World,8085A CPU,yes,Phoenix,Taito Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 fantzn2,Fantasy Zone II - The Tears of Opa-Opa (SSE),Japan,"MC8123, 317-0057",no,,Sega System E,,no,no,1988,Sega,Shooter - Flying Horizontal,,15kHz,horizontal,,,1,8-way,,2

--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -610,7 +610,7 @@ extrmatnj,Extermination (JP),Japan,,yes,Extermination,Taito The NewZealand Story
 extrmatnu,"Extermination (US, World Games)",USA,World Games,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito (World Games license),Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 extrmatnur,"Extermination (US, Romstar)",USA,Romstar,yes,Extermination,Taito The NewZealand Story hardware,Extermination,no,no,1987,Taito America Corporation (Romstar license),Shooter - Walking,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 eyes,"Eyes (US, Set 1)",USA,Set 1,no,,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
-eyes2,Eyes (US Set 2),USA,Set 2,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+eyes2,"Eyes (US, Set 2)",USA,Set 2,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Rock-Ola,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 eyeszac,Eyes (IT),Italy,,yes,Eyes,Namco Pac-Man hardware,,no,no,1982,Techstar - Zaccaria,Maze - Collect,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 f1dream,F-1 Dream,World,,no,F-1 Dream,Capcom CPS-0,,no,no,1988,Capcom,Driving - Race,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 falcon,Falcon (8085A CPU) [bl],World,8085A CPU,yes,Phoenix,Taito Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1


### PR DESCRIPTION
All three Eyes rows spell the manufacturer "Tehstar". It should be "Techstar". Reported by a user of the MiSTerZine arcade index, which surfaces the MAD manufacturer field.

The MAD already spells it correctly on the other Techstar games running on the same Namco Pac-Man hardware, so the Eyes rows are the outliers:

- gorkans: Techstar
- mrtnt: Techstar - Telko
- lizwiz: Techstar - Sunn

Changes (3 rows):

1. eyes, eyes2, eyeszac: manufacturer "Tehstar" -> "Techstar".

2. eyeszac: licensee "Rock-Ola" -> "Zaccaria". This is the Italian release. MAME/arcadeitalia lists it as "Techstar (Zaccaria license)", not Rock-Ola. Following the existing "X - Y" convention used by mrtnt and lizwiz, the row becomes "Techstar - Zaccaria".
   http://adb.arcadeitalia.net/dettaglio_mame.php?game_name=eyeszac

3. eyes2 and eyeszac: name field corrected to match the distributed MRA filenames, so the generated "file" value resolves to a real file. Currently it does not:

   eyes2:   name "Eyes (US, Set 2)" -> file "Eyes (US, Set 2).mra", but the distributed file is _Arcade/_alternatives/_Eyes/Eyes (US set 2).mra
   eyeszac: name "Eyes (IT)"        -> file "Eyes (IT).mra",        but the distributed file is _Arcade/_alternatives/_Eyes/Eyes (Italy).mra

   Set to "Eyes (US set 2)" and "Eyes (Italy)" respectively. Both new values are unique in the CSV, so no name collision. The parent row is already correct ("Eyes (US, Set 1)" matches _Arcade/Eyes (US, Set 1).mra) and its name is untouched.

Sources:
- eyes:    http://adb.arcadeitalia.net/dettaglio_mame.php?game_name=eyes    (Techstar (Rock-Ola license), 1982)
- eyes2:   http://adb.arcadeitalia.net/dettaglio_mame.php?game_name=eyes2   (Techstar (Rock-Ola license), 1982)
- eyeszac: http://adb.arcadeitalia.net/dettaglio_mame.php?game_name=eyeszac (Techstar (Zaccaria license), 1982)

Note on the root cause: the typo originates upstream in the MRAs themselves, which all ship <manufacturer>Tehstar</manufacturer>. The MAD rows inherited it. Fixing those is separate from this PR: the parent MRA lives in Arcade-Pacman_MiSTer/releases/, and the two alternatives are maintained directly in Distribution_MiSTer under _Arcade/_alternatives/_Eyes/. This PR fixes the database only.

No rotation or flip fields are touched, so there is no change to which systems these download to and nothing here required a hardware test.
