### PR TITLE
Fix year typos and Hanafram manufacturer typo (22 rows)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -418,7 +418,7 @@ contrae,"Contra (US-AS, Set 3)",USA - Asia,Set 3,no,Contra,Konami Contra based,C
 contraj,"Contra (JP, Set 1)",Japan,Set 1,yes,Contra,Konami Contra based,Contra,no,no,1987,Konami,Platform - Shooter Scrolling,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 contraj1,"Contra (JP, Set 2)",Japan,Set 2,yes,Contra,Konami Contra based,Contra,no,no,1987,Konami,Platform - Shooter Scrolling,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 coozumou,Oozumou - Grand Sumo,Japan,,no,Oozumou - Grand Sumo,Data East DECO Cassette,,no,no,1984,Data East,Sports - Wrestling,,15kHz,vertical (ccw),,,2 (alternating),,,2
-cosmica,Cosmic Alien,World,,no,,Universal Cosmic hardware,,no,no,1981,Universal,Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way,,1
+cosmica,Cosmic Alien,World,,no,,Universal Cosmic hardware,,no,no,1979,Universal,Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way,,1
 cosmo,Cosmo,World,,no,invaders,Midway 8080,,no,no,1979,TDS &amp; MINTS,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,2
 cotton,"Cotton (W, Set 4)",World,Set 4,no,Cotton,Sega System 16,Cotton,no,no,1991,Sega,Shooter - Flying Horizontal,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
 cottonj,"Cotton (JP, Set 2, Rev B)",Japan,"Set 2, Rev B",yes,Cotton,Sega System 16,Cotton,no,no,1991,Sega,Shooter - Flying Horizontal,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
@@ -713,7 +713,7 @@ frogger,Frogger (Konami Bugfixed),World,Konami Bugfixed,no,Frogger,Konami Z80,,n
 froggers2,"Frogger (Sega, Set 2)",World,"Sega, Set 2",yes,Frogger,Konami Z80,,no,no,1981,Konami,Maze - Cross,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 fshark,Flying Shark (W),World,,yes,Flying Shark,Toaplan Twin Cobra hardware,,no,no,1987,Toaplan - Taito Corporation,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 fstpman2,New Puck 2 (Fast) [hb],World,Fast,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Namco - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
-futspy,Future Spy,World,,no,,Sega Zaxxon based,,no,no,1982,Sega-Gremlin,Shooter - Flying Diagonal,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
+futspy,Future Spy,World,,no,,Sega Zaxxon based,,no,no,1984,Sega-Gremlin,Shooter - Flying Diagonal,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
 gaia,Gaia Crusaders,World,,no,Gaia Crusaders,CAVE 68000,,no,no,1999,CAVE,Fighter - 2.5D,,15kHz,horizontal,no,,2 (simultaneous),8-way,,4
 galaga,Galaga (Namco Rev. B),World,Namco Rev. B,yes,Galaga,Namco Galaga based,Galaga,no,no,1981,Namco,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 galaga3,Galaga 3 (GP3 Rev D),World,GP3 Rev D,yes,Gaplus,Namco Galaga based,Galaga,no,no,1984,Namco,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,1
@@ -838,7 +838,7 @@ gteikokub2,Gingateikoku no Gyakushu (Set 2) [bl],Japan,Set 2,yes,UniWar S,Irem U
 gteikokub3,Gingateikoku no Gyakushu (Set 3) [bl],Japan,Set 3,yes,UniWar S,Irem Unique,,no,yes,1980,Honly,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 gulfwar2,Gulf War II (Set 1),World,set 1,no,Gulf War II,Toaplan Twin Cobra hardware,,no,no,1991,Comad,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 gulfwar2a,Gulf War II (Set 2),World,set 2,yes,Gulf War II,Toaplan Twin Cobra hardware,,no,no,1991,Comad,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
-gulunpa,"Gulun.Pa (931220 L, Prototype)",World,"931220 L, Prototype",no,,Capcom CPS-1,,no,no,1990,Capcom,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
+gulunpa,"Gulun.Pa (931220 L, Prototype)",World,"931220 L, Prototype",no,,Capcom CPS-1,,no,no,1993,Capcom,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
 gunfight,Gun Fight,World,,no,,Midway 8080,,no,no,1975,Dave Nutting Associates - Midway,Shooter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,0
 gunforc2,Gun Force II (US),USA,,no,Gun Force II,Irem M92,Gun Force,no,no,1994,Irem,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 gunforce,Gun Force (W),World,,yes,Gun Force,Irem M92,Gun Force,no,no,1991,Irem,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -1208,7 +1208,7 @@ nrallyx,New Rally-X,World,,no,Rally-X,Namco Pac-Man hardware,Rally-X,no,no,1981,
 nrallyxb,New Rally-X [bl],World,,yes,Rally-X,Namco Pac-Man hardware,Rally-X,no,yes,1981,Namco,Maze - Driving,,15kHz,horizontal,,,2 (alternating),8-way,,1
 nslasher,"Night Slashers (KR Rev 1.3, DE-0397-0 PCB)",Korea,"Rev 1.3, DE-0397-0 PCB",no,Night Slashers,Data East DE-0397 hardware,,no,no,1994,Data East Corporation,Fighter - 2.5D,,15kHz,horizontal,,,3 (simultaneous),8-way,,3
 nspiritj,Ninja Spirit (JP),Japan,,no,Ninja Spirit,Irem M72,,no,no,1989,Irem,Fighter - 2D,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
-numcrash,Number Crash,World,Set 1,no,,Namco Pac-Man hardware,Pac-Man,no,no,1980,Hanshin Goraku - Peni,Platform - Run Jump,,15kHz,vertical (cw),no,,1,4-way,,
+numcrash,Number Crash,World,Set 1,no,,Namco Pac-Man hardware,Pac-Man,no,no,1983,Hanshin Goraku - Peni,Platform - Run Jump,,15kHz,vertical (cw),no,,1,4-way,,
 nwarr,"Night Warriors- Darkstalkers' Revenge (EU, 950316)",Europe,950316,no,,Capcom CPS-2,Darkstalkers,no,no,1995,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
 nwarra,"Night Warriors- Darkstalkers' Revenge (AS, 950302)",Asia,950302,yes,Night Warriors- Darkstalkers' Revenge,Capcom CPS-2,Darkstalkers,no,no,1995,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
 nwarrb,"Night Warriors- Darkstalkers' Revenge (W, 950403)",World,950403,yes,Night Warriors- Darkstalkers' Revenge,Capcom CPS-2,Darkstalkers,no,no,1995,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
@@ -1377,8 +1377,8 @@ pmgrenp,Pac-Man Green Plus [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,Pac-Ma
 pnickj,"Pnickies (JP, 940608)",Japan,940608,no,,Capcom CPS-1,,no,no,1994,Capcom,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
 pokonyan,"Pokonyan! Balloon (JP, 940322)",Japan,940322,no,,Capcom CPS-1,,no,no,1994,Capcom,Misc. - Hot-air Balloon,,15kHz,horizontal,n-a,,1,8-way,,3
 polyplay,Poly Play,World,,no,,Poly Play hardware,,no,no,1985,VEB Polytechnik,MultiGame - Compilation,,15kHz,horizontal,,,1,8-way,,1
-polyplay2,Poly Play 2,World,,no,,Poly Play hardware,,no,no,1985,VEB Polytechnik,Maze - Collect,,15kHz,horizontal,,,1,8-way,,1
-polyplay2c,Poly Play 2c,World,,no,,Poly Play hardware,,no,no,1985,VEB Polytechnik,Maze - Collect,,15kHz,horizontal,,,1,8-way,,1
+polyplay2,Poly Play 2,World,,no,,Poly Play hardware,,no,no,1989,VEB Polytechnik,Maze - Collect,,15kHz,horizontal,,,1,8-way,,1
+polyplay2c,Poly Play 2c,World,,no,,Poly Play hardware,,no,no,1989,VEB Polytechnik,Maze - Collect,,15kHz,horizontal,,,1,8-way,,1
 pompingw,Pomping World (JP),Japan,,yes,Pang,Capcom Mitchell,Pang!,no,no,1989,Mitchell,Shooter - 3rd Person,,15kHz,horizontal,,,2 (simultaneous),4-way,,2
 pong,Pong (Rev E),World,Rev E,no,,Atari Discrete hardware,,no,no,1972,Atari,TTL - Ball &amp; Paddle - Pong,,15kHz,horizontal,,,2 (simultaneous),,positional,0
 ponpoko,Ponpoko,World,,no,,Namco Pac-Man hardware,,no,no,1982,Sigma,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),4-way,,1
@@ -1728,7 +1728,7 @@ shangon1,Super Hang-On (mini ride-on),World,,yes,Super Hang-On,Sega Out Run hard
 shangon2,"Super Hang-On (mini ride-on, Rev A)",World,,yes,Super Hang-On,Sega Out Run hardware,Hang-On,no,no,1987,Sega,Driving - Motorbike,,15kHz,horizontal,,,1,Wheel,,3
 shangon3d,Super Hang-On (sitdown - upright) [bl],World,bootleg of FD1089B 317-0034 set,yes,Super Hang-On,Sega Out Run hardware,Hang-On,no,yes,1987,Sega,Driving - Motorbike,,15kHz,horizontal,,,1,Wheel,,3
 shangon3,Super Hang-On (sitdown - upright),World,,yes,Super Hang-On,Sega Out Run hardware,Hang-On,no,no,1987,Sega,Driving - Motorbike,,15kHz,horizontal,,,1,Wheel,,3
-shangonle,Limited Edition Hang-On,World,,no,Super Hang-On,Sega Out Run hardware,Hang-On,no,no,1987,Sega,Driving - Motorbike,,15kHz,horizontal,,,1,Wheel,,3
+shangonle,Limited Edition Hang-On,World,,no,Super Hang-On,Sega Out Run hardware,Hang-On,no,no,1991,Sega,Driving - Motorbike,,15kHz,horizontal,,,1,Wheel,,3
 shangon3,Super Hang-On (sitdown - upright) [bl],World,,yes,Super Hang-On,Sega Out Run hardware,Hang-On,no,yes,1987,Sega,Driving - Motorbike,,15kHz,horizontal,,,1,Wheel,,3
 shaolinb,Shao-lin's Road (Set 2),World,,yes,,Konami 6809 based,,no,no,1985,Konami,Platform - Fighter,,15kHz,vertical (cw),,,2 (alternating),4-way,,2
 shaolins,Shao-lin's Road (Set 1),World,,yes,,Konami 6809 based,,no,no,1985,Konami,Platform - Fighter,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,2
@@ -1740,9 +1740,9 @@ shinobi4,"Shinobi (W, S16B, Set 4)",World,"S16B, Set 4",yes,Shinobi,Sega System 
 shinobi5,"Shinobi (W, S16B, Set 5) No Protection",World,"S16B, Set 5, No Protection",yes,Shinobi,Sega System 16,Shinobi,no,no,1987,Sega,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,3
 shinobi6,"Shinobi (W, S16B, Set 6), No Protection",World,"S16B, Set 6, No Protection",no,Shinobi,Sega System 16,Shinobi,no,no,1987,Sega,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,3
 shippumd,Shippu Mahou Daisakusen (JP),Japan,,yes,Kingdom Grandprix,Toaplan 2,,no,no,1994,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
-shollow,Satan's Hollow (Set 1),World,Set 1,no,,Midway MCR2,,no,no,1983,Bally - Midway,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,2
+shollow,Satan's Hollow (Set 1),World,Set 1,no,,Midway MCR2,,no,no,1981,Bally - Midway,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,2
 shollow2,Satan's Hollow (Set 2),World,Set 2,yes,Satan's Hollow,Midway MCR2,,no,no,1981,Bally - Midway,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,2
-shtrider,Shot Rider (B-Board 89624B-1),World,B-Board 89624B-1,no,,Irem M52,,no,no,1983,Capcom,Driving - Motorbike,,15kHz,vertical (ccw),yes,,2 (alternating),8-way,,
+shtrider,Shot Rider (B-Board 89624B-1),World,B-Board 89624B-1,no,,Irem M52,,no,no,1985,Capcom,Driving - Motorbike,,15kHz,vertical (ccw),yes,,2 (alternating),8-way,,
 shtron,Satan's Hollow (Tron Hardware) [bl],World,Tron Hardware,yes,Tron,Midway MCR3,,no,yes,1983,Bally - Midway,MultiGame - Mini-Games,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,2
 shuffle,Shuffleboard,World,,no,,Midway 8080,,no,no,1978,Midway,Sports - Shuffleboard,,15kHz,vertical (cw),yes,,1,,trackball,1
 shuttlei,Shuttle Invader,World,,no,,Midway 8080,,no,no,1979,"Omori Electric Co., Ltd.",Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,1
@@ -1785,7 +1785,7 @@ smbomb,"Super Muscle Bomber- The International Blowout (JP, 940831)",Japan,94083
 smbombr1,"Super Muscle Bomber- The International Blowout (JP, 940808)",Japan,940808,yes,Super Muscle Bomber- The International Blowout,Capcom CPS-2,Muscle Bomber,no,no,1994,Capcom,Sports - Wrestling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
 snapjack,Snap Jack,World,,no,,Universal Lady Bug,,no,no,1982,Universal,"Platform - Run, Jump &amp; Scrolling",,15kHz,horizontal,,,2 (alternating),8-way,,0
 snapper,Snapper (KR),Korea,,no,Snapper,Sega System 16,,no,no,1990,Philko,Maze - Collect,,15kHz,horizontal,n-a,,1,8-way,,3
-snowbro2,Snow Bros. 2 - With New Elves - Otenki Paradise (Hanafram),World,,no,Snow Bros. 2,Toaplan 2,Snow Bros,no,no,1994,Hanafarm,Platform - Run Jump,,15kHz,horizontal,,,4 (simultaneous),8-way,,2
+snowbro2,Snow Bros. 2 - With New Elves - Otenki Paradise (Hanafram),World,,no,Snow Bros. 2,Toaplan 2,Snow Bros,no,no,1994,Hanafram,Platform - Run Jump,,15kHz,horizontal,,,4 (simultaneous),8-way,,2
 snowbros,Snow Bros. - Nick & Tom (Set 1),World,Set 1,yes,Snow Bros. - Nick & Tom,Toaplan Snow Bros hardware,,no,no,1990,Toaplan,Platform - Run Jump,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 snowbrosa,Snow Bros. - Nick & Tom (Set 2),World,Set 2,yes,Snow Bros. - Nick & Tom,Toaplan Snow Bros hardware,,no,no,1990,Toaplan,Platform - Run Jump,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 snowbrosb,Snow Bros. - Nick & Tom (Set 3),World,Set 3,yes,Snow Bros. - Nick & Tom,Toaplan Snow Bros hardware,,no,no,1990,Toaplan,Platform - Run Jump,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -1906,7 +1906,7 @@ sutapper,Tapper (Suntory),World,Suntory,yes,Tapper,Midway MCR3,,no,no,1983,Bally
 svg,S.V.G. - Spectral vs Generation (ver. 200),World,ver. 200,no,S.V.G. - Spectral vs Generation,IGS PGM,,no,no,2005,IGS / Idea Factory,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 swarm,Swarm [bl],World,,yes,Galaxian,Namco Galaxian based,,no,yes,1979,Subelectro,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 swat,SWAT (315-5048),World,315-5048,no,,Sega System 1,,no,no,1984,Sega,Shooter - Field,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,2
-sxevious,Super Xevious,World,,no,xevious,Namco Galaga based,,no,no,1982,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
+sxevious,Super Xevious,World,,no,xevious,Namco Galaga based,,no,no,1984,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
 szaxxon,Super Zaxxon,World,,no,,Sega Zaxxon based,,no,no,1982,Sega-Gremlin,Shooter - Flying Diagonal,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,1
 tankbatt,Tank Battalion,World,,no,Tank Battalion,Namco Unique,Tank Battalion,no,no,1980,Namco,Maze - Shooter Small,,15kHz,vertical (cw),,,2 (alternating),4-way,,1
 tapper,"Tapper (Budweiser, 840127)",World,"Budweiser, 840127",no,,Midway MCR3,,no,no,1983,Bally - Midway,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),4-way,,1
@@ -2070,12 +2070,12 @@ vigilantc,"Vigilante (W, Rev C)",World,,yes,Vigilante,Irem M75,,no,no,1988,Irem,
 vigilantd,"Vigilante (JP, Rev D)",Japan,,no,Vigilante,Irem M75,,no,no,1988,Irem,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 vigilantg,"Vigilante (US, Rev G)",USA,,yes,Vigilante,Irem M75,,no,no,1988,Irem,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
 vigilanto,Vigilante (US),USA,,yes,Vigilante,Irem M75,,no,no,1988,Irem,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
-vimana,"Vimana (W, Set 1)",World,,yes,Vimana,Toaplan 1,,no,no,1989,Toaplan,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
-vimanaj,Vimana (JP),Japan,,no,Vimana,Toaplan 1,,no,no,1989,Toaplan,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
-vimanan,"Vimana (W, Set 2)",World,Set 2,yes,Vimana,Toaplan 1,,no,no,1989,Toaplan,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
-vindctr2,Vindicators Part II (Rev 3),World,Rev 3,no,,Atari Gauntlet based,Vindicators,no,no,1985,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
-vindctr2r1,Vindicators Part II (Rev 1),World,Rev 1,yes,Vindicators Part II,Atari Gauntlet based,Vindicators,no,no,1985,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
-vindctr2r2,Vindicators Part II (Rev 2),World,Rev 2,yes,Vindicators Part II,Atari Gauntlet based,Vindicators,no,no,1985,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
+vimana,"Vimana (W, Set 1)",World,,yes,Vimana,Toaplan 1,,no,no,1991,Toaplan,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+vimanaj,Vimana (JP),Japan,,no,Vimana,Toaplan 1,,no,no,1991,Toaplan,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+vimanan,"Vimana (W, Set 2)",World,Set 2,yes,Vimana,Toaplan 1,,no,no,1991,Toaplan,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+vindctr2,Vindicators Part II (Rev 3),World,Rev 3,no,,Atari Gauntlet based,Vindicators,no,no,1988,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
+vindctr2r1,Vindicators Part II (Rev 1),World,Rev 1,yes,Vindicators Part II,Atari Gauntlet based,Vindicators,no,no,1988,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
+vindctr2r2,Vindicators Part II (Rev 2),World,Rev 2,yes,Vindicators Part II,Atari Gauntlet based,Vindicators,no,no,1988,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
 vortex,Vortex,World,,no,,Taito 8080,,no,no,1980,Zilec Electronics,Shooter - Field,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,1
 vpacbell,Vector Pac-Man (Bell) [hb],World,Bell,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Namco - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 vpacelec,Vector Pac-Man (Electric Cowboy) [hb],World,Electric Cowboy,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Namco - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
@@ -2136,7 +2136,7 @@ wofa,"Sangokushi II (AS, 921005)",Asia,921005,yes,Sangokushi II,Capcom CPS-1.5,,
 wofhfh,"Huo Feng Huang (CN, Sangokushi II) [bl]",China,"Chinese, Sangokushi II",yes,Sangokushi II,Capcom CPS-1,,no,yes,1999,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,1
 wofj,"Tenchi wo Kurau II- Sekiheki no Tatakai (JP, 921031)",Japan,921031,yes,Dynasty Wars,Capcom CPS-1.5,Dynasty Wars,no,no,1992,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,3 (simultaneous),8-way,,2
 wofu,"Warriors of Fate (US, 921031)",USA,921031,yes,Dynasty Wars,Capcom CPS-1.5,Dynasty Wars,no,no,1992,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,3 (simultaneous),8-way,,2
-wofch,"Tenchi wo Kurau II- Sekiheki no Tatakai (JP, CPS Changer, 921031)",Japan,CPS Changer,yes,Dynasty Wars,Capcom CPS-1.5,Dynasty Wars,no,no,1992,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,3 (simultaneous),8-way,,2
+wofch,"Tenchi wo Kurau II- Sekiheki no Tatakai (JP, CPS Changer, 921031)",Japan,CPS Changer,yes,Dynasty Wars,Capcom CPS-1.5,Dynasty Wars,no,no,1994,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,3 (simultaneous),8-way,,2
 wonder3,"Wonder 3 (JP, 910520)",Japan,910520,yes,Three Wonders,Capcom CPS-1,,no,no,1991,Capcom,MultiGame - Compilation,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
 woodpeck,Woodpecker (Set 1),World,Set 1,no,,Namco Pac-Man hardware,,no,no,1981,Amenip - Palcom Queen River,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,1
 wow,Wizard of Wor,World,,no,,Midway Astrocade,,no,no,1980,Dave Nutting Associates - Midway,Maze - Shooter Small,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -2260,8 +2260,8 @@ redbaron,Red Baron (Revised Hardware),World,Revised Hardware,no,Red Baron,Atari 
 freeze,Freeze,World,,no,Freeze,Cinematronics Jack The Giantkiller hardware,Freeze,no,no,1984,Cinematronics,Maze - Shooter,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,2
 jack,Jack The Giantkiller (Set 1),World,Set 1,no,Jack The Giantkiller,Cinematronics Jack The Giantkiller hardware,Jack The Giantkiller,no,no,1982,Cinematronics,Climbing - Tree - Plant,,15kHz,vertical (cw),,,2 (alternating),8-way,,2
 sucasino,Super Casino,World,,no,Super Casino,Cinematronics Jack The Giantkiller hardware,Super Casino,no,no,1984,Data Amusement,Casino - Cards,,15kHz,vertical (cw),,,2 (alternating),2-way horizontal,,1
-tripool,Tri-Pool (Casino Tech),World,Casino Tech,no,Tri-Pool,Cinematronics Jack The Giantkiller hardware,Tri-Pool,no,no,1984,Noma (Casino Tech license),Sports - Pool,,15kHz,vertical (cw),,,2 (alternating),8-way,,5
-zzyzzyxx,Zzyzzyxx,World,,no,Zzyzzyxx,Cinematronics Jack The Giantkiller hardware,Zzyzzyxx,no,no,1984,Cinematronics,Maze - Escape,,15kHz,vertical (cw),,,2 (alternating),2-way vertical,,1
+tripool,Tri-Pool (Casino Tech),World,Casino Tech,no,Tri-Pool,Cinematronics Jack The Giantkiller hardware,Tri-Pool,no,no,1981,Noma (Casino Tech license),Sports - Pool,,15kHz,vertical (cw),,,2 (alternating),8-way,,5
+zzyzzyxx,Zzyzzyxx,World,,no,Zzyzzyxx,Cinematronics Jack The Giantkiller hardware,Zzyzzyxx,no,no,1982,Cinematronics,Maze - Escape,,15kHz,vertical (cw),,,2 (alternating),2-way vertical,,1
 dsoccr94j,"Dream Soccer '94 (JP, M92)",Japan,,no,Dream Soccer '94,Irem M92,Dream Soccer,no,no,1994,Irem,Sports - Soccer,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 majtitl2,"Major Title 2 (W, Set 1)",World,,no,Major Title 2,Irem M92,Major Title,no,no,1992,Irem,Sports - Golf,,15kHz,horizontal,,,4 (simultaneous),8-way,,2
 ssoldier,Superior Soldiers (US),USA,,no,Superior Solders,Irem M92,Superior Soldiers,no,no,1994,Irem,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
@@ -2494,7 +2494,7 @@ esckids,"Escape Kids (AS, 4P)",Asia,,no,,Konami Vendetta hardware,,no,no,1991,Ko
 esckidsj,"Escape Kids (JP, 2P)",Japan,,no,Escape Kids,Konami Vendetta hardware,,no,no,1991,Konami,Sports - Track &amp; Field,,15kHz,horizontal,,,2-4 (simultaneous),8-way,,2
 twincobr,Twin Cobra (W),World,,no,,Toaplan Twin Cobra hardware,Twin Cobra,no,no,1987,Toaplan - Taito Corporation,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
 twincobru,Twin Cobra (US),USA,,yes,Twin Cobra,Toaplan Twin Cobra hardware,Twin Cobra,no,no,1987,Toaplan - Taito America Corporation (Romstar license),Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
-ktiger,"Kyukyoku Tiger (JP, 2P Co-op)",Japan,2 player cooperative,no,Twin Cobra,Toaplan Twin Cobra hardware,Twin Cobra,no,no,1987,Toaplan - Taito Corporation,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
+ktiger,"Kyukyoku Tiger (JP, 2P Co-op)",Japan,2 player cooperative,no,Twin Cobra,Toaplan Twin Cobra hardware,Twin Cobra,no,no,1989,Toaplan - Taito Corporation,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
 ktigera,"Kyukyoku Tiger (JP, 2P Alt)",Japan,2 player alternating,yes,Twin Cobra,Toaplan Twin Cobra hardware,Twin Cobra,no,no,1987,Toaplan - Taito Corporation,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
 splatter,"Splatter House (W, New Version (SH3))",World,"New Version, SH3",no,,Namco System-1,,no,no,1988,Namco,Fighter - 2.5D,,15kHz,horizontal,,,2 (alternating),8-way,,2
 splatterj,"Splatter House (JP, SH1)",Japan,SH1,yes,Splatter House,Namco System-1,,no,no,1988,Namco,Fighter - 2.5D,,15kHz,horizontal,,,2 (alternating),8-way,,2
@@ -2550,7 +2550,7 @@ quester,Quester (JP),Japan,,no,,Namco System-1,,no,no,1987,Namco,Ball &amp; Padd
 questers,Quester Special Edition (JP),Japan,,no,Quester,Namco System-1,,no,no,1987,Namco,Ball &amp; Paddle - Breakout,,15kHz,vertical (cw),yes,,2 (alternating),Dial,Dial,1
 ws,Pro Yakyuu World Stadium (JP),Japan,,no,,Namco System-1,World Stadium,no,no,1988,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 ws89,Pro Yakyuu World Stadium '89 (JP),Japan,,no,Pro Yakyuu World Stadium,Namco System-1,World Stadium,no,no,1988,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
-ws90,Pro Yakyuu World Stadium '90 (JP),Japan,,no,Pro Yakyuu World Stadium,Namco System-1,World Stadium,no,no,1988,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
+ws90,Pro Yakyuu World Stadium '90 (JP),Japan,,no,Pro Yakyuu World Stadium,Namco System-1,World Stadium,no,no,1990,Namco,Sports - Baseball,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 berabohm,"Chou Zetsurinjin Berabowman (JP, Rev C)",Japan,Rev C,no,,Namco System-1,,no,no,1988,Namco,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,6
 berabohmb,"Chou Zetsurinjin Berabowman (JP, Rev B)",Japan,Rev B,yes,Chou Zetsurinjin Berabowman,Namco System-1,,no,no,1988,Namco,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,6
 mmaze,Marchen Maze (JP),Japan,,no,,Namco System-1,,no,no,1988,Namco,Maze - Shooter Large,,15kHz,horizontal,,,2 (alternating),8-way,,3


### PR DESCRIPTION
Fixes found by cross-checking MAD against MAME metadata (ArcadeItalia ADB mirror).

21 year corrections where MAD is off by 2+ years on an original release (left MAD, right MAME):

numcrash 1980->1983, 
cosmica 1981->1979, 
futspy 1982->1984, 
sxevious 1982->1984, 
shollow 1983->1981, 
shtrider 1983->1985, 
tripool 1984->1981, 
zzyzzyxx 1984->1982, 
polyplay2 1985->1989, 
polyplay2c 1985->1989, 
vindctr2 1985->1988, 
vindctr2r1 1985->1988, 
vindctr2r2 1985->1988, 
shangonle 1987->1991, 
ktiger 1987->1989, 
ws90 1988->1990, 
vimana 1989->1991, 
vimanaj 1989->1991, 
vimanan 1989->1991, 
gulunpa 1990->1993, 
wofch 1992->1994

Several look like a clone row inheriting the parent or series year (e.g. Vindicators Part II got Vindicators' 1985).

1 manufacturer typo: snowbro2 "Hanafarm" -> "Hanafram". The row's own name field already says "(Hanafram)", and MAME agrees.

Deliberately NOT included, flagging as questions instead:
- Rows where MAD dates a hack/re-release by the original game but MAME dates the derivative (Bubble Bobble Redux 2013, Out Run Enhanced Editions, Wonder Boy Virtual Console 2009, kagekih 1992, samesamenh 2015, punisherbz 2002, gaplust Tecfri 1992). If you have a preferred policy, happy to do a follow-up either way.
- arkatayt/arktayt2 credit "Taito" but MAME says bootleg (Tayto) - "Tayto" being the bootlegger's brand. Your call.
- 65 rows where MAD and MAME differ by exactly 1 year were left alone (usually development vs release year sourcing).
