### PR TITLE
Add 32 rows for arcade cores released since PR #125 (Psikyo SH-2, Sega G80 Vector, laserdisc, misc)

### DIFF
--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -611,6 +611,7 @@ dkpace,Donkey Kong Pace (Pace) [hb],World,Pace,yes,Donkey Kong,Donkey Kong hardw
 dkrainbow,Rainbow Donkey Kong [hb],World,,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dkrdemo,"Donkey Kong (Remix, Rev 1.8) [hb]",World,"Remix, Rev 1.8",yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
 dktrainer,Donkey Kong Trainer (v1.01) [hb],World,v1.01,yes,Donkey Kong,Donkey Kong hardware,Donkey Kong,yes,no,1981,Nintendo,Platform - Run Jump,,15kHz,vertical (cw),no,,2 (alternating),4-way,,1
+dlair,Dragon's Lair,USA,,no,Dragon's Lair,Cinematronics Laserdisc,,no,no,1983,Cinematronics,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),8-way,,1
 dland,Dream Land- Super Dream Land (Bubble Bobble) [bl],World,Bubble Bobble,yes,Bubble Bobble,Taito Bubble Booble based,Bubble Bobble,no,yes,1986,Taito,Platform - Run Jump,,15kHz,horizontal,n-a,,2 (simultaneous),2-way horizontal,,2
 dmnfrnt,Demon Front (ver. 105),World,ver. 105,no,Demon Front,IGS PGM,,no,no,2002,IGS,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 dogosoke,Dogou Souken,Japan,,yes,Victory Road,SNK Triple Z80,,no,no,1986,SNK,Shooter - Walking,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
@@ -881,6 +882,7 @@ gradius3a,Gradius III (AS),Asia,,yes,Gradius III,Konami Gradius III hardware,Gra
 gradius3j,"Gradius III Densetsu kara Shinwa e (JP, version 3, newer)",Japan,"version 3, newer",yes,Gradius III Densetsu kara Shinwa e,Konami Gradius III hardware,Gradius,no,no,1989,Konami,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
 gradius3ja,"Gradius III Densetsu kara Shinwa e (JP, version S)",Japan,version S,yes,Gradius III Densetsu kara Shinwa e,Konami Gradius III hardware,Gradius,no,no,1989,Konami,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
 gradius3jas,"Gradius III Densetsu kara Shinwa e (JP, version S, split)",Japan,"version S, split",yes,Gradius III Densetsu kara Shinwa e,Konami Gradius III hardware,Gradius,no,no,1989,Konami,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,3
+grainbow,SD Gundam Sangokushi Rainbow Tairiku Senki (JP),Japan,,no,SD Gundam Sangokushi Rainbow Tairiku Senki,Seibu Legionnaire hardware,,no,no,1993,Banpresto,Platform - Shooter Scrolling,,15kHz,horizontal,,,4 (simultaneous),8-way,,3
 grasspin,Grasspin (Jaleco),World,,no,Grasspin,Blue Print hardware,,no,no,1983,Zilec Electronics / Jaleco,,,15kHz,vertical (ccw),,,2 (alternating),8-way,,2
 gravitar,Gravitar (Ver 3),World,Ver 3,no,,Atari Vector,,no,no,1982,Atari,Shooter - Field,,31kHz,horizontal,,,1,2-way horizontal,,3
 grobda,"Grobda (W, New Ver.)",World,New Ver.,no,,Namco Super Pac-Man hardware,,no,no,1984,Namco,Maze - Shooter Small,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
@@ -1047,6 +1049,7 @@ killiped,Killipede [hb],World,,yes,Centipede,Atari Centipede based,,yes,no,1980,
 kingball,King and Balloon (US),USA,,no,,Namco Galaxian based,,no,no,1980,Namco,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 kingballj,King and Balloon,World,,no,,Namco Galaxian based,,no,no,1980,Namco,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 kingdmgp,Kingdom Grandprix,World,,no,Kingdom Grandprix,Toaplan 2,,no,no,1994,Raizing - Eighting,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,3
+klax,Klax,World,,no,Klax,Atari Klax hardware,,no,no,1990,Atari Games,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),4-way,,1
 knights,"Knights of the Round (W, 911127)",World,911127,no,,Capcom CPS-1,,no,no,1991,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
 knightsj,"Knights of the Round (JP, 911127, B-Board 91634B-2)",Japan,"911127, B-Board 91634B-2",yes,Knights of the Round,Capcom CPS-1,,no,no,1991,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
 knightsja,"Knights of the Round (JP, 911127, B-Board 89625B-1)",Japan,"911127, B-Board 89625B-1",yes,Knights of the Round,Capcom CPS-1,,no,no,1991,Capcom,Fighter - 2.5D,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
@@ -1932,6 +1935,7 @@ sonsonj,SonSon (JP),Japan,,yes,SonSon,Capcom CPS-0,SonSon,no,no,1984,Capcom,Plat
 sosterm,S.O.S.,World,,no,,TIAMC1,,no,no,1988,Terminal,"Platform - Run, Jump &amp; Scrolling",,15kHz,horizontal,,,1,4-way,,1
 spacbat2,Space Battle (Set 2) [bl],World,Set 2,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 spacbatt,Space Battle (Set 1) [bl],World,Set 1,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
+spaceace,Space Ace,USA,,no,Space Ace,Cinematronics Laserdisc,,no,no,1983,Cinematronics,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),8-way,,1
 SpaceDemon,Space Demon,World,,no,Space Firebird,Nintendo Arcade,,no,no,1980,Nintendo (Fortrek license),Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,2
 spacefb,Space Firebird,World,,no,Space Firebird,Nintendo Arcade,,no,no,1980,Nintendo,Shooter - Gallery,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,2
 spacempr,Space Empire [bl],World,,yes,UniWar S,Irem Unique,,no,yes,1980,,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
@@ -2016,6 +2020,7 @@ starjack,Star Jacker (Sega),World,Sega,no,,Sega System 1,,no,no,1983,Sega,Shoote
 starjacks,Star Jacker (Alt),World,Alt,yes,Star Jacker,Sega System 1,,no,no,1983,Sega,Shooter - Flying Vertical,,15kHz,vertical (ccw),no,,2 (alternating),8-way,,2
 starslayer,Starslayer (Asteroids) [hb],World,Asteroids,yes,Asteroids,Atari Vector,,yes,no,1979,Atari,Shooter - Field,,31kHz,horizontal,,,1,2-way horizontal,,3
 starsldr,Star Soldier - Vanishing Earth,World,,no,Star Soldier - Vanishing Earth,Nintendo Aleck64 hardware,,no,no,1998,Hudson Soft / Seta,Shooter - Flying Vertical,,,horizontal,,,1,8-way,,4
+startrek,Star Trek,World,,no,Star Trek,Sega G80 Vector,,no,no,1982,Sega,Shooter - Flying 1st Person,,31kHz,horizontal (180),,,2 (alternating),,spinner,4
 starwars,Star Wars (Rev 2),World,Rev 2,no,Star Wars,Atari Vector,Star Wars,no,no,1983,Atari,Shooter - Flying 1st Person,,31kHz,horizontal,,,1,,Stick,4
 stratgys,Strategy X (Stern),World,Stern,yes,Strategy X,Konami Scramble based,,no,no,1981,Konami - Stern,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (alternating),8-way,,3
 stratgyx,Strategy X,World,,no,,Konami Scramble based,,no,no,1981,Konami,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (alternating),8-way,,3
@@ -2046,6 +2051,7 @@ swarm,Swarm [bl],World,,yes,Galaxian,Namco Galaxian based,,no,yes,1979,Subelectr
 swat,SWAT (315-5048),World,315-5048,no,,Sega System 1,,no,no,1984,Sega,Shooter - Field,,15kHz,vertical (ccw),no,,2 (alternating),4-way,,2
 sxevious,Super Xevious,World,,no,xevious,Namco Galaga based,,no,no,1984,Namco,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
 szaxxon,Super Zaxxon,World,,no,,Sega Zaxxon based,,no,no,1982,Sega-Gremlin,Shooter - Flying Diagonal,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,1
+tacscan,Tac-Scan,World,,no,Tac-Scan,Sega G80 Vector,,no,no,1982,Sega,Shooter - Flying Vertical,,31kHz,vertical (ccw),,,2 (alternating),,spinner,2
 tankbatt,Tank Battalion,World,,no,Tank Battalion,Namco Unique,Tank Battalion,no,no,1980,Namco,Maze - Shooter Small,,15kHz,vertical (cw),,,2 (alternating),4-way,,1
 tapper,"Tapper (Budweiser, 840127)",World,"Budweiser, 840127",no,,Midway MCR3,,no,no,1983,Bally - Midway,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),4-way,,1
 tappera,"Tapper (Budweiser, 831209)",World,"Budweiser, 831209",yes,Tapper,Midway MCR3,,no,no,1983,Bally - Midway,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),4-way,,1
@@ -2097,6 +2103,7 @@ tokioo,Tokio (Scramble Formation) (Older),World,Older,yes,Scramble Formation,Tai
 tokiou,Tokio (Scramble Formation) (US),USA,,yes,Scramble Formation,Taito Bubble Booble based,,no,no,1986,Taito,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 tokisens,"Toki no Senshi - Chrono Soldier [MC-8123, 317-0040]",Japan,"MC-8123, 317-0040",no,,Sega System 1,,no,no,1987,Sega,Shooter - Walking,,15kHz,vertical (cw),,,1,8-way,,2
 tokisensa,Toki no Senshi - Chrono Soldier (prototype),Japan,"MC-8123, 317-0040",yes,Toki no Senshi - Chrono Soldier,Sega System 1,,no,no,1987,Sega,Shooter - Walking,,15kHz,vertical (cw),,,1,8-way,,2
+toobin,Toobin,World,,no,Toobin,Atari System-1,,no,no,1988,Atari Games,Sports - Misc.,,15kHz,vertical (ccw),,,2 (simultaneous),,,5
 topgunbl,Top Gunner (US) [bl],USA,,yes,Jackal,Konami Double Dribble based,,no,yes,1986,Konami,Shooter - Driving Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 topgunr,Top Gunner (US),USA,,yes,Jackal,Konami Double Dribble based,,no,no,1986,Konami,Shooter - Driving Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,2
 topsecrt,"Top Secret (JP, Rev Old)",Japan,Rev Old,yes,Bionic Commando,Capcom CPS-0,,no,no,1987,Capcom,Platform - Shooter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2

--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -487,6 +487,7 @@ daimakair,"Daimakaimura (JP, Resale)",Japan,Resale,yes,Ghouls 'n Ghosts,Capcom C
 dairesya,Dai Ressya Goutou (Ver. K),Japan,,yes,,Konami Double Dribble based,,no,no,1986,Konami,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,3
 dakkochn,Dakkochan House (MC-8123),World,MC-8123,no,,Sega System 1,,no,no,1987,Sega,Tabletop - Mahjong [Mature],,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 dangar,Ufo Robo Dangar (4-07-1987),World,,no,Ufo Robo Dangar,Nichibutsu Z80 (Galivan),Ufo Robo Dangar,no,no,1987,Nichibutsu,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (alternating),8-way,,3
+daraku,Daraku Tenshi The Fallen Angels,World,,no,Daraku Tenshi The Fallen Angels,Psikyo SH-2 hardware,,no,no,1998,Psikyo,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 darius,Darius (W),World,,no,Darius,Taito Darius hardware,Darius,no,no,1986,Taito Corporation Japan,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 darius2,"Darius II (JP, rev 1)",Japan,rev 1,no,Darius II,Taito Ninja Warriors hardware,Darius,no,no,1989,Taito Corporation,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 darius2d,"Darius II (JP, dual screen, rev 2)",Japan,"dual screen, rev 2",no,Darius II,Taito Warrior Blade hardware,Darius,no,no,1989,Taito Corporation,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -630,6 +631,7 @@ dotrikun2,Dottori-Kun (Old),World,Old,no,,Dottori-Kun hardware,,no,no,1990,Sega,
 dotriman,Dottori-Man Jr [hb],World,,no,,Dottori-Kun hardware,,yes,no,1990,Chris Covell,Maze - Driving,,15kHz,horizontal,no,,1,8-way,,2
 dotron,Discs of Tron,World,,no,,Midway MCR3,Tron,no,no,1983,Bally - Midway,Sports - Misc.,,15kHz,horizontal,,,1,8-way,,4
 dotrona,Discs of Tron (Alt.),World,Alt.,yes,Discs of Tron,Midway MCR3,,no,no,1983,Bally - Midway,Sports - Misc.,,15kHz,horizontal,,,1,8-way,,4
+dragnblz,Dragon Blaze,World,,no,Dragon Blaze,Psikyo SH-2 hardware,,no,no,2000,Psikyo,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,3
 dremshpr,Dream Shopper,World,,no,,Namco Pac-Man hardware,,no,no,1982,Sanritsu,Puzzle - Maze,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
 drgninja,"Dragonninja (JP, Rev. 1)",Japan,Rev. 1,no,Bad Dudes vs. Dragonninja,Data East MEC-M1,,no,no,1988,Data East,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,2
 drgw3,Dragon World 3 (ver. 106),World,ver. 106,no,Dragon World 3,IGS PGM,Dragon World,no,no,1998,IGS,Tabletop - Shanghai,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
@@ -854,6 +856,7 @@ gigawingh,"Giga Wing (HS, 990222)",Hispanic,990222,yes,Giga Wing,Capcom CPS-2,,n
 gigawingj,"Giga Wing (JP, 990222)",Japan,990222,yes,Giga Wing,Capcom CPS-2,,no,no,1999,Takumi - Takumi,Shooter - Flying Vertical,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,2
 gigawingjd,"Giga Wing (JP, Phoenix Edition) [bl]",Japan,Phoenix Edition,yes,Giga Wing,Capcom CPS-2,,no,no,1999,Takumi - Takumi,Shooter - Flying Vertical,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,2
 gmahou,"Great Mahou Daisakusen (JP, 000121)",Japan,121,yes,Dimahoo,Capcom CPS-2,,no,no,2000,Eighting - Raizing - Capcom,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,n-a,3
+gnbarich,Gunbarich,World,,no,Gunbarich,Psikyo SH-2 hardware,,no,no,2001,Psikyo,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),,,2 (alternating),8-way,,3
 gng,Ghosts'n Goblins (W),World,"JT, Set 1",no,,Capcom CPS-0,Ghosts 'n,no,no,1985,Capcom,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),4-way,,2
 gnga,"Ghosts'n Goblins (W, Set 2)",World,,yes,,Capcom CPS-0,Ghosts 'n,no,no,1985,Capcom,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),4-way,,2
 gngbl,Ghosts'n Goblins (Bootleg with Cross) [bl],World,,yes,,Capcom CPS-0,Ghosts 'n,no,yes,1985,Capcom,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),4-way,,2
@@ -893,6 +896,7 @@ gulfwar2,Gulf War II (Set 1),World,set 1,no,Gulf War II,Toaplan Twin Cobra hardw
 gulfwar2a,Gulf War II (Set 2),World,set 2,yes,Gulf War II,Toaplan Twin Cobra hardware,,no,no,1991,Comad,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
 gulunpa,"Gulun.Pa (931220 L, Prototype)",World,"931220 L, Prototype",no,,Capcom CPS-1,,no,no,1993,Capcom,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
 gunball,Gun Ball (JP),Japan,,yes,Nitro Ball,Data East Rohga hardware,,no,no,1992,Data East Corporation,Shooter - Walking,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
+gunbird2,Gunbird 2 (Set 1),World,Set 1,no,Gunbird 2,Psikyo SH-2 hardware,,no,no,1998,Psikyo,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,3
 gunfight,Gun Fight,World,,no,,Midway 8080,,no,no,1975,Dave Nutting Associates - Midway,Shooter - Versus,,15kHz,horizontal,,,2 (alternating),8-way,,0
 gunforc2,Gun Force II (US),USA,,no,Gun Force II,Irem M92,Gun Force,no,no,1994,Irem,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 gunforce,Gun Force (W),World,,yes,Gun Force,Irem M92,Gun Force,no,no,1991,Irem,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
@@ -925,6 +929,7 @@ hellfire,Hellfire (2P set),World,2P Set,no,Hellfire,Toaplan 1,,no,no,1989,Toapla
 hellfire1,Hellfire (1P set),World,1P Set,yes,Hellfire,Toaplan 1,,no,no,1989,Toaplan (Taito license),Shooter - Flying Horizontal,,15kHz,horizontal,,,1,8-way,,2
 hellfire1a,"Hellfire (1P set, older)",World,1P Set,yes,Hellfire,Toaplan 1,,no,no,1989,Toaplan (Taito license),Shooter - Flying Horizontal,,15kHz,horizontal,,,1,8-way,,2
 hellfire2a,"Hellfire (2P set, older)",World,2P Set,yes,Hellfire,Toaplan 1,,no,no,1989,Toaplan (Taito license),Shooter - Flying Horizontal,,15kHz,horizontal,,,1,8-way,,2
+hgkairak,Taisen Hot Gimmick Kairakuten (JP),Japan,,no,Taisen Hot Gimmick Kairakuten,Psikyo SH-2 hardware,,no,no,1998,Psikyo,Tabletop - Mahjong,,15kHz,horizontal,,,2 (alternating),,mahjong,
 hharryu,"Hammerin' Harry (US, M84 hardware)",USA,,no,Hammerin' Harry,Irem M72,,no,no,1990,Irem,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 higemaru,Pirate Ship Higemaru,World,,no,,Capcom CPS-0,,no,no,1984,Capcom,Maze - Collect,,15kHz,horizontal,n-a,,2 (alternating),4-way,,1
 hipai,Hi Pai Paradise,World,,no,Hi Pai Paradise,Nintendo Aleck64 hardware,,no,no,2003,Aruze / Seta,Tabletop - Mahjong,,,horizontal,,,1,,mahjong,
@@ -946,7 +951,12 @@ horekid,Kid no Hore Hore Daisakusen,Japan,,no,Kid no Hore Hore Daisakusen,Nichib
 horekidb,Kid no Hore Hore Daisakusen (Set 1) [bl],Japan,,yes,Kid no Hore Hore Daisakusen,Nichibutsu M68000 (Terra Cresta),,no,yes,1987,Nichibutsu,Maze - Defeat Enemies,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
 horekidb2,Kid no Hore Hore Daisakusen (Set 2) [bl],Japan,,yes,Kid no Hore Hore Daisakusen,Nichibutsu M68000 (Terra Cresta),,no,yes,1987,Nichibutsu,Maze - Defeat Enemies,,15kHz,vertical (cw),yes,,2 (alternating),8-way,,2
 horizon,Horizon (Irem),World,,no,,Irem M62,,no,no,1985,Irem,Shooter - Driving Horizontal,,15kHz,horizontal,,,2 (alternating),8-way,,2
+hotdebut,Quiz de Idol! Hot Debut (JP),Japan,,no,Quiz de Idol! Hot Debut,Psikyo SH-2 hardware,,no,no,2000,MOSS / Psikyo,Quiz - Questions in Japanese,,15kHz,horizontal,,,4 (simultaneous),,,4
 hotdogst,Hotdog Storm,World,,no,Hotdog Storm,CAVE 68000,,no,no,1996,Marble,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,,3
+hotgm4ev,Taisen Hot Gimmick 4 Ever (JP),Japan,,no,Taisen Hot Gimmick 4 Ever,Psikyo SH-2 hardware,,no,no,2000,Psikyo,Tabletop - Mahjong,,15kHz,horizontal,,,2 (alternating),,mahjong,
+hotgmck,Taisen Hot Gimmick (JP),Japan,,no,Taisen Hot Gimmick,Psikyo SH-2 hardware,,no,no,1997,Psikyo,Tabletop - Mahjong,,15kHz,horizontal,,,2 (alternating),,mahjong,
+hotgmck3,Taisen Hot Gimmick 3 Digital Surfing (JP),Japan,,no,Taisen Hot Gimmick 3 Digital Surfing,Psikyo SH-2 hardware,,no,no,1999,Psikyo,Tabletop - Mahjong,,15kHz,horizontal,,,2 (alternating),,mahjong,
+hotgmcki,Mahjong Hot Gimmick Integral (JP),Japan,,no,Mahjong Hot Gimmick Integral,Psikyo SH-2 hardware,,no,no,2001,Psikyo,Tabletop - Mahjong,,15kHz,horizontal,,,2 (simultaneous),,mahjong,
 housepty,House Party [hb],World,,yes,Mappy,Namco Super Pac-Man hardware,,yes,no,1983,Jerky,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 hpolym84,Hyper Olympic '84,World,,yes,,Konami 6809 based,,no,no,1984,Konami,Sports - Track &amp; Field,,15kHz,horizontal,,,4 (alternating),,,3
 hsf2,"Hyper Street Fighter II- The Anniversary Edition (US, 040202)",USA,40202,no,,Capcom CPS-2,Street Fighter,no,no,2004,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,6
@@ -1087,6 +1097,7 @@ lizwiz,Lizard Wizard,World,,no,,Namco Pac-Man hardware,,no,no,1985,Techstar - Su
 llander,Lunar Lander (Rev 2),World,Rev 2,no,,Atari 6502,,no,no,1979,Atari,Driving - Landing,,31kHz,horizontal,,,1,2-way horizontal,,1
 llander1,Lunar Lander (Rev 1),World,Rev 1,yes,Lunar Lander,Atari 6502,,no,no,1979,Atari,Driving - Landing,,31kHz,horizontal,,,1,2-way horizontal,,1
 lockonph,"Lock On (W, Philko)",World,,no,Lock On (Philko),Sega System 16,,no,no,1991,Philko,Shooter - Flying Horizontal,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,2
+loderndf,Lode Runner - The Dig Fight (ver. B),World,ver. B,no,Lode Runner - The Dig Fight,Psikyo SH-2 hardware,,no,no,2000,Psikyo,Platform - Run Jump,,15kHz,horizontal,,,4 (simultaneous),8-way,,3
 lohtj,Legend of Hero Tonma (JP),Japan,,no,Legend of Hero Tonma,Irem M72,,no,no,1989,Irem,Fighter - 2D,,15kHz,horizontal,,,2 (alternating),8-way,,2
 losttomb,Lost Tomb,World,,no,Lost Tomb,Konami Scramble based,,no,no,1982,Stern,Maze - Shooter Small,,15kHz,vertical (cw),yes,,1,8-way,twin stick,4
 losttombh,Lost Tomb (Hard),World,Hard,yes,Lost Tomb,Konami Scramble based,,no,no,1982,Stern,Maze - Shooter Small,,15kHz,vertical (cw),no,,1,8-way,twin stick,4
@@ -1161,6 +1172,7 @@ minefld,Minefield,World,,no,,Konami Scramble based,,no,no,1983,Stern,Shooter - D
 missile,Missile Command (Rev 3),USA,,no,Missile Command,Atari Missile Command,,no,no,1980,Atari,Shooter - Command,,15kHz,horizontal,,,2 (alternating),Trackball,,3
 missile1,Missile Command (Rev 1),USA,,yes,Missile Command,Atari Missile Command,,no,no,1980,Atari,Shooter - Command,,15kHz,horizontal,,,2 (alternating),Trackball,,3
 missile2,Missile Command (Rev 2),USA,,yes,Missile Command,Atari Missile Command,,no,no,1980,Atari,Shooter - Command,,15kHz,horizontal,,,2 (alternating),Trackball,,3
+mjgtaste,Mahjong G-Taste,World,,no,Mahjong G-Taste,Psikyo SH-2 hardware,,no,no,2002,Psikyo,Tabletop - Mahjong,,15kHz,horizontal,,,1,,mahjong,
 mjleague,"Major League (W, S16A)",World,"S16A, No Protection",no,Major League,Sega System 16,,no,no,1985,Sega,Sports - Baseball,,15kHz,vertical (ccw),yes,,2 (simultaneous),,,2
 mmancp2u,"Mega Man- The Power Battle (US, CPS2, 951006, SAMPLE Ver)",USA,"CPS2, 951006, SAMPLE Version",yes,Mega Man- The Power Battle,Capcom CPS-2,Mega Man,no,no,1995,Capcom,Fighter - Versus Co-op,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,3
 mmancp2ur1,"Mega Man- The Power Battle (US, CPS2, 950926, SAMPLE Ver)",USA,"CPS2, 950926, SAMPLE Version",yes,Mega Man- The Power Battle,Capcom CPS-2,Mega Man,no,no,1995,Capcom,Fighter - Versus Co-op,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,3
@@ -1630,6 +1642,8 @@ rygar3,"Rygar (US, Set 3 Old Ver)",USA,Set 3,yes,Rygar,Tecmo hardware,Rygar,no,n
 rygarj,Arashi no Senshi,Japan,,no,Rygar,Tecmo hardware,Rygar,no,no,1986,Tecmo,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 ryukyu,"RyuKyu (JP, Rev A) 317-5023A",Japan,"Rev A, FD1094 317-5023A",no,RyuKyu,Sega System 16,,no,no,1990,Sega,Puzzle - Cards,,15kHz,horizontal,n-a,,1,8-way,,2
 ryukyua,RyuKyu (JP) [FD1094 317-5023],Japan,FD1094 317-5023,yes,RyuKyu,Sega System 16,,no,no,1990,Sega,Puzzle - Cards,,15kHz,horizontal,n-a,,1,8-way,,2
+s1945ii,Strikers 1945 II,World,,no,Strikers 1945 II,Psikyo SH-2 hardware,,no,no,1997,Psikyo,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
+s1945iii,Strikers 1945 III,World,,no,Strikers 1945 III,Psikyo SH-2 hardware,,no,no,1999,Psikyo,Shooter - Flying Vertical,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,3
 sagaia,"Sagaia (W, dual screen)",World,dual screen,no,Darius II,Taito Warrior Blade hardware,Darius,no,no,1989,Taito Corporation Japan,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 sailormn,"Pretty Soldier Sailor Moon (Version 95-03-22B, EU)",Europe,Version 95-03-22B,no,Pretty Soldier Sailor Moon,CAVE 68000,,no,no,1995,Banpresto / Gazelle,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 sailormnh,"Bishoujo Senshi Sailor Moon (Version 95-03-22B, HK)",Hong Kong,Version 95-03-22B,yes,Pretty Soldier Sailor Moon,CAVE 68000,,no,no,1995,Banpresto / Gazelle,Fighter - 2.5D,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
@@ -1676,6 +1690,7 @@ sboblbobla,Super Bobble Bobble (Set 2) [bl],World,Set 2,yes,Bubble Bobble,Taito 
 sboblboblb,Super Bobble Bobble (Set 3) [bl],World,Set 3,yes,Bubble Bobble,Taito Bubble Booble based,Bubble Bobble,no,yes,1986,Taito,Platform - Run Jump,,15kHz,horizontal,n-a,,2 (simultaneous),2-way horizontal,,2
 sboblboblc,Super Bubble Bobble [bl],World,,yes,Bubble Bobble,Taito Bubble Booble based,Bubble Bobble,no,yes,1986,Taito,Platform - Run Jump,,15kHz,horizontal,n-a,,2 (simultaneous),2-way horizontal,,2
 sboblbobld,Super Bobble Bobble (Set 4) [bl],World,Set 4,yes,Bubble Bobble,Taito Bubble Booble based,Bubble Bobble,no,yes,1986,Taito,Platform - Run Jump,,15kHz,horizontal,n-a,,2 (simultaneous),2-way horizontal,,2
+sbomber,Space Bomber (ver. B),World,ver. B,no,Space Bomber,Psikyo SH-2 hardware,,no,no,1998,Psikyo,Shooter - Gallery,,15kHz,vertical (ccw),,,2 (simultaneous),8-way,,2
 sbrkout,Super Breakout (Rev 04),World,Rev 04,no,,Atari 6502,Breakout,no,no,1978,Atari,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),no,,1,,spinner,1
 sbrkoutct,"Super Breakout (Cocktail, Prototype)",World,"Cocktail, Prototype",yes,Super Breakout,Atari 6502,Breakout,no,no,1978,Atari,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),no,,1,,spinner,1
 schaser,Space Chaser,World,,no,,Taito 8080,,no,no,1979,Taito,Maze - Collect,,15kHz,vertical (ccw),yes,,2 (alternating),4-way,,1
@@ -1907,6 +1922,7 @@ snowbrosd,Snow Bros. - Nick & Tom (Dooyong License),World,Dooyong License,yes,Sn
 snowbrosj,Snow Bros. - Nick & Tom (JP),Japan,,no,Snow Bros. - Nick & Tom,Toaplan Snow Bros hardware,,no,no,1990,Toaplan,Platform - Run Jump,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
 snowpac,Snowy Day Pac-Man [hb],World,,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,T-Bone,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 solarfox,Solar Fox,World,,no,,Midway MCR1,,no,no,1980,Bally - Midway,Maze - Shooter Small,,15kHz,vertical (cw),no,,2 (alternating),4-way,,2
+soldivid,Sol Divide Sword Of Darkness,World,,no,Sol Divide Sword Of Darkness,Psikyo SH-2 hardware,,no,no,1997,Psikyo,Shooter - Flying Horizontal,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
 solomon,Solomon's Key,World,,no,,Solomon's Key hardware,,no,no,1986,Tecmo,Puzzle - Maze,,15kHz,horizontal,,,2 (alternating),8-way,,2
 solomonj,Solomon no Kagi (JP),Japan,,yes,Solomon's Key,Solomon's Key hardware,,no,no,1986,Tecmo,Puzzle - Maze,,15kHz,horizontal,,,2 (alternating),8-way,,2
 solomonjs01,Solomon no Kagi (CN) [hb],China,Chinese,yes,Solomon's Key,Solomon's Key hardware,,yes,no,1986,Tecmo,Puzzle - Maze,,15kHz,horizontal,,,2 (alternating),8-way,,2
@@ -2049,6 +2065,7 @@ tetris1,"Tetris (JP, S16B, Set 1)",Japan,Set 1,no,Tetris,Sega System 16,Tetris,n
 tetris2,"Tetris (JP, S16B, Set 2)",Japan,Set 2,yes,Tetris,Sega System 16,Tetris,no,no,1988,Sega,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
 tetris3,"Tetris (JP, S16A, Set 3)",Japan,Set 3,yes,Tetris,Sega System 16,Tetris,no,no,1988,Sega,Puzzle - Drop,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,3
 tetrisse,"Tetris (JP, System E)",Japan,System E,no,,Sega System E,,no,no,1988,Sega,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,2
+tgm2,Tetris The Absolute - The Grand Master 2,World,,no,Tetris The Absolute - The Grand Master 2,Psikyo SH-2 hardware,,no,no,2000,Arika,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),4-way,,3
 theend,The End,World,,no,,Konami Scramble based,,no,no,1980,Konami,Shooter - Gallery,,15kHz,vertical (cw),yes,,2 (alternating),2-way horizontal,,1
 theends,The End (Stern),World,Stern,yes,The End,Konami Scramble based,,no,no,1980,Konami - Stern,Shooter - Gallery,,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,,1
 theglad,The Gladiator (ver. 107),World,ver. 107,no,The Gladiator,IGS PGM,,no,no,2003,IGS,Fighter - 2.5D,,15kHz,horizontal,,,2-4 (simultaneous),8-way,,4

--- a/ArcadeDatabase.csv
+++ b/ArcadeDatabase.csv
@@ -244,6 +244,7 @@ block,"Block Block (W, 911219, Joystick)",World,,no,Block Block,Capcom Mitchell,
 blockade,Blockade,World,,no,,Sega Blockade hardware,,no,no,1976,Gremlin,Maze - Surround,,15kHz,horizontal,,,2 (simultaneous),,,
 blockgal,Block Gal,World,,no,Block Gal,Sega System 1,,no,no,1987,Sega,Ball &amp; Paddle - Breakout [Mature],,15kHz,vertical (cw),no,,2 (alternating),2-way horizontal,spinner,0
 blockj,"Block Block (JP, 910910)",Japan,,yes,Block Block,Capcom Mitchell,Block Block,no,no,1991,Capcom,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),,,2 (simultaneous),2-way horizontal,,2
+blockout,Block Out (Set 1),World,Set 1,no,Block Out,Technos Block Out hardware,,no,no,1989,Technos Japan / California Dreams,Puzzle - Drop,,15kHz,horizontal,,,2 (simultaneous),8-way,,4
 blockr1,"Block Block (W, 911106, Joystick)",World,,yes,Block Block,Capcom Mitchell,Block Block,no,no,1991,Capcom,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),,,2 (simultaneous),2-way horizontal,,2
 blockr2,"Block Block (W, 910910)",World,,yes,Block Block,Capcom Mitchell,Block Block,no,no,1991,Capcom,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),,,2 (simultaneous),2-way horizontal,,2
 bloodbro,Blood Bros (W),World,,no,Blood Bros,Seibu Blood Bros hardware,,no,no,1990,TAD Corporation,Shooter - 3rd Person,,15kHz,horizontal,,,2 (simultaneous),8-way,,3
@@ -856,6 +857,7 @@ gigawingd,"Giga Wing (US, Phoenix Edition) [bl]",USA,Phoenix Edition,yes,Giga Wi
 gigawingh,"Giga Wing (HS, 990222)",Hispanic,990222,yes,Giga Wing,Capcom CPS-2,,no,no,1999,Takumi - Takumi,Shooter - Flying Vertical,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,2
 gigawingj,"Giga Wing (JP, 990222)",Japan,990222,yes,Giga Wing,Capcom CPS-2,,no,no,1999,Takumi - Takumi,Shooter - Flying Vertical,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,2
 gigawingjd,"Giga Wing (JP, Phoenix Edition) [bl]",Japan,Phoenix Edition,yes,Giga Wing,Capcom CPS-2,,no,no,1999,Takumi - Takumi,Shooter - Flying Vertical,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,n-a,2
+gijoe,"G.I. Joe (W, EAB)",World,EAB,no,G.I. Joe,Konami G.I. Joe hardware,,no,no,1992,Konami,Shooter - 3rd Person,,15kHz,horizontal,,,4 (simultaneous),8-way,,3
 gmahou,"Great Mahou Daisakusen (JP, 000121)",Japan,121,yes,Dimahoo,Capcom CPS-2,,no,no,2000,Eighting - Raizing - Capcom,Shooter - Flying Vertical,,15kHz,vertical (cw),yes,,2 (simultaneous),8-way,n-a,3
 gnbarich,Gunbarich,World,,no,Gunbarich,Psikyo SH-2 hardware,,no,no,2001,Psikyo,Ball &amp; Paddle - Breakout,,15kHz,vertical (ccw),,,2 (alternating),8-way,,3
 gng,Ghosts'n Goblins (W),World,"JT, Set 1",no,,Capcom CPS-0,Ghosts 'n,no,no,1985,Capcom,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),4-way,,2
@@ -1578,6 +1580,8 @@ rastsaga,"Rastan Saga (JP, Rev 1)",Japan,,yes,,Taito 68000 based,,no,no,1987,Tai
 rastsagaa,"Rastan Saga (JP, Rev 1, earlier code base)",Japan,,yes,,Taito 68000 based,,no,no,1987,Taito,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 rastsagab,"Rastan Saga (JP, earlier code base)",Japan,,yes,,Taito 68000 based,,no,no,1987,Taito,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 rastsagaabl,"Rastan Saga (JP, Rev 1, earlier code base) [bl]",Japan,,yes,,Taito 68000 based,,no,no,1987,Taito,Platform - Fighter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
+rbisland,Rainbow Islands (rev 1),World,rev 1,no,Rainbow Islands,Taito 68000 based,Bubble Bobble,no,no,1987,Taito,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),2-way horizontal,,2
+rbislande,Rainbow Islands - Extra Version,World,,no,Rainbow Islands,Taito 68000 based,Bubble Bobble,no,no,1988,Taito,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),2-way horizontal,,2
 rbtapper,Tapper (Root Beer),World,Root Beer,yes,Tapper,Midway MCR3,,no,no,1983,Bally - Midway,Platform - Run Jump,,15kHz,horizontal,,,2 (alternating),4-way,,1
 reactor,Reactor,World,,no,Reactor,Konami Unique,,no,no,1982,Gottlieb,Maze - Shooter Small,,15kHz,horizontal,,,2 (alternating),,trackball,2
 redearthn,"Red Earth (AS 961121, NO CD)",Asia,"961121, NO CD",no,Red Earth,Capcom CPS-3,,no,no,1996,Capcom,Fighter - Versus Co-op,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
@@ -1746,6 +1750,7 @@ sf2ceua,"Street Fighter II'- Champion Edition (US, 920313)",USA,920313,yes,Stree
 sf2ceub,"Street Fighter II'- Champion Edition (US, 920513)",USA,920513,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2ceuc,"Street Fighter II'- Champion Edition (US, 920803)",USA,920803,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2ceupl,Street Fighter II'- Champion Edition (UPL) [bl],World,UPL,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,yes,1992,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
+sf2cre,"Street Fighter II' Champion Re-Edit (Hack, v0.29.7)",World,"Hack, v0.29.7",no,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
 sf2ea,"Street Fighter II- The Warrior (W, 910204)",World,910204,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1991,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2eb,"Street Fighter II- The Warrior (W, 910214)",World,910214,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1991,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2ed,"Street Fighter II- The Warrior (W, 910318)",World,910318,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1991,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
@@ -1753,6 +1758,7 @@ sf2em,"Street Fighter II- The Warrior (W, 910129)",World,910129,yes,Street Fight
 sf2en,"Street Fighter II- The Warrior (W, 910204, Conversion)",World,"910204, Conversion",yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1991,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2hf,"Street Fighter II'- Hyper Fighting (W, 921209)",World,921209,no,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2hfj,"Street Fighter II' Turbo- Hyper Fighting (JP, 921209)",Japan,921209,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
+sf2hfsce,Street Fighter II' Special Champion Edition (Sr Street hack),World,Sr Street hack,no,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,,,2 (simultaneous),8-way,,6
 sf2hfu,"Street Fighter II'- Hyper Fighting (US, 921209)",USA,921209,yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1992,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2j,"Street Fighter II- The Warrior (JP, 911210, CPS-B-13)",Japan,"911210, CPS-B-13",yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1991,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
 sf2j17,"Street Fighter II- The Warrior (JP, 911210, CPS-B-17)",Japan,"911210, CPS-B-17",yes,Street Fighter II,Capcom CPS-1,Street Fighter,no,no,1991,Capcom,Fighter - Versus,,15kHz,horizontal,n-a,,2 (simultaneous),8-way,,6
@@ -2078,6 +2084,7 @@ theglad,The Gladiator (ver. 107),World,ver. 107,no,The Gladiator,IGS PGM,,no,no,
 theglobp,The Glob (Pac-Man Hardware),World,Pac-Man Hardware,no,,Namco Pac-Man hardware,,no,no,1983,Epos Corporation,Platform - Run Jump,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,2
 theroes,Thunder Heroes,World,,no,Thunder Heroes,CAVE 68000,,no,no,2001,CAVE,Fighter - 2.5D,,15kHz,horizontal,no,,2 (simultaneous),8-way,,4
 thndblst,Thunder Blaster (JP),Japan,,yes,Lethal Thunder,Irem M92,Lethal Thunder,no,no,1992,Irem,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (simultaneous),8-way,,2
+thndzone,"Thunder Zone (W, Rev 1)",World,Rev 1,no,Thunder Zone,Data East Thunder Zone hardware,,no,no,1991,Data East Corporation,Shooter - Walking,,15kHz,horizontal,,,4 (simultaneous),8-way,,2
 thoop,"Thunder Hoop (ver. 1, checksum 02a09f7d)",World,ver. 1,no,Thunder Hoop,Gaelco hardware,,no,no,1992,Gaelco,Platform - Shooter Scrolling,,15kHz,horizontal,,,2 (alternating),8-way,,2
 tigerhb1,Tiger Heli [bl],World,,no,Tiger Heli,Toaplan Slap Fight hardware,Tiger Heli,no,no,1985,Toaplan - Taito,Shooter - Flying Vertical,,15kHz,vertical (ccw),yes,,2 (alternating),8-way,,2
 tigeroad,Tiger Road,World,,no,Tiger Road,Capcom CPS-0,,no,no,1987,Capcom,Platform - Fighter Scrolling,,15kHz,horizontal,n-a,,2 (alternating),8-way,,2
@@ -2233,6 +2240,7 @@ vindctr2,Vindicators Part II (Rev 3),World,Rev 3,no,,Atari Gauntlet based,Vindic
 vindctr2r1,Vindicators Part II (Rev 1),World,Rev 1,yes,Vindicators Part II,Atari Gauntlet based,Vindicators,no,no,1988,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
 vindctr2r2,Vindicators Part II (Rev 2),World,Rev 2,yes,Vindicators Part II,Atari Gauntlet based,Vindicators,no,no,1988,Atari,Shooter - Driving Vertical,,15kHz,horizontal,,,2 (simultaneous),2-way vertical,twin stick,4
 vivdolls,Vivid Dolls,World,,no,Vivid Dolls,Nintendo Aleck64 hardware,,no,no,1998,Visco,Puzzle - Outline,,,horizontal,,,2 (simultaneous),8-way,,
+volfied,"Volfied (W, rev 1)",World,rev 1,no,Volfied,Taito Volfied hardware,,no,no,1989,Taito,Puzzle - Outline,,15kHz,vertical (ccw),,,2 (alternating),4-way,,1
 vortex,Vortex,World,,no,,Taito 8080,,no,no,1980,Zilec Electronics,Shooter - Field,,15kHz,vertical (ccw),yes,,2 (alternating),2-way horizontal,,1
 vpacbell,Vector Pac-Man (Bell) [hb],World,Bell,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Namco - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0
 vpacelec,Vector Pac-Man (Electric Cowboy) [hb],World,Electric Cowboy,yes,Pac-Man,Namco Pac-Man hardware,Pac-Man,yes,no,1980,Namco - Midway,Maze - Collect,,15kHz,vertical (cw),yes,,2 (alternating),4-way,,0


### PR DESCRIPTION
32 games that ship as MRAs but have no MAD row.

Rotation and inputs from the MAME driver source, the rest from adb.arcadeitalia.net. flip left blank, nothing hardware tested.

- Psikyo SH-2 (17 rows): new PsikyoSH2 core, psikyosh.cpp + psikyo4.cpp. New platform string.
- MiSTer-devel cores (7 rows): Klax, Toobin, Star Trek, Tac/Scan, Dragon's Lair, Space Ace, SD Gundam Rainbow. Two more new platforms, "Sega G80 Vector" (31kHz, like the Atari Vector rows) and "Cinematronics Laserdisc". grainbow is legionna.cpp, so it rides the existing Seibu Legionnaire hardware.
- jotego and Coin-Op Collection (8 rows): Block Out, Volfied, Rainbow Islands x2, two SF2' hacks shipped by jtcps1, G.I. Joe, Thunder Zone.

Two things worth a look:

- players comes from the MAME input ports rather than nplayers.ini for thndzone, grainbow and loderndf. All three have P3/P4 ports (and grainbow has START3/4), nplayers.ini says 2P.
- sf2cre and sf2hfsce are jotego setnames, not MAME sets, so the specs are sf2ce's. Happy to drop them if you would rather not carry hack rows keyed that way.
